### PR TITLE
Fix mobile navbar overflow by making nav links wrap on small screens

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -59,14 +59,14 @@ const navLinks = [
     <div class="mx-auto min-h-screen w-full max-w-6xl px-6 pb-20 pt-8 md:px-10">
       <header class="sticky top-4 z-20 mb-14">
         <nav
-          class="mx-auto flex w-fit items-center gap-2 rounded-full border border-zinc-800/90 bg-zinc-900/80 px-3 py-2 shadow-lg shadow-black/30 backdrop-blur"
+          class="mx-auto flex w-full max-w-2xl flex-wrap items-center justify-center gap-1 rounded-3xl border border-zinc-800/90 bg-zinc-900/80 px-2 py-2 shadow-lg shadow-black/30 backdrop-blur sm:w-fit sm:rounded-full sm:px-3"
           aria-label="Page sections"
         >
           <a
             v-for="link in navLinks"
             :key="link.href"
             :href="link.href"
-            class="rounded-full px-3 py-1.5 text-sm text-zinc-300 transition hover:bg-zinc-800 hover:text-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300"
+            class="rounded-full px-2.5 py-1.5 text-xs text-zinc-300 transition hover:bg-zinc-800 hover:text-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 sm:px-3 sm:text-sm"
           >
             {{ link.label }}
           </a>


### PR DESCRIPTION
### Motivation
- Prevent the header navigation from overflowing horizontally on narrow viewports by allowing the nav to use a wrapped, full-width layout on small screens.

### Description
- Updated the header `<nav>` to use `w-full max-w-2xl flex-wrap items-center justify-center` with `sm:w-fit` and `sm:rounded-full` to enable wrapping on mobile while restoring the compact pill layout on `sm` and up, and adjusted link classes to `px-2.5 text-xs` with `sm:px-3 sm:text-sm` so nav pills fit without clipping (`app/pages/index.vue`).

### Testing
- Ran `pnpm run build` successfully to ensure production build passes. 
- Started the dev server with `pnpm run dev --host 0.0.0.0 --port 3000` and verified a mobile viewport (`390x844`) via a Playwright screenshot which confirmed the overflow is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857b926bd48333a82bf5544cea9e0f)