### PR TITLE
Adopt light Anthropic-inspired styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .nitro
 .cache
 dist
+node-compile-cache
 
 # Node dependencies
 node_modules

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
 
 body {
-  @apply dark:bg-zinc-950 dark:text-zinc-50;
+  @apply bg-stone-50 text-stone-900 antialiased;
 }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -52,32 +52,32 @@ const navLinks = [
 </script>
 
 <template>
-  <div class="relative overflow-x-clip bg-zinc-950 text-zinc-50">
-    <div class="pointer-events-none absolute -left-28 top-8 h-72 w-72 rounded-full bg-emerald-400/20 blur-3xl" />
-    <div class="pointer-events-none absolute -right-28 top-64 h-72 w-72 rounded-full bg-sky-500/20 blur-3xl" />
+  <div class="relative overflow-x-clip bg-stone-50 text-stone-900">
+    <div class="pointer-events-none absolute -left-32 top-6 h-72 w-72 rounded-full bg-amber-200/40 blur-3xl" />
+    <div class="pointer-events-none absolute -right-32 top-56 h-72 w-72 rounded-full bg-rose-200/40 blur-3xl" />
 
     <div class="mx-auto min-h-screen w-full max-w-6xl px-6 pb-20 pt-8 md:px-10">
       <header class="sticky top-4 z-20 mb-14">
         <nav
-          class="mx-auto flex w-full max-w-2xl flex-wrap items-center justify-center gap-1 rounded-3xl border border-zinc-800/90 bg-zinc-900/80 px-2 py-2 shadow-lg shadow-black/30 backdrop-blur sm:w-fit sm:rounded-full sm:px-3"
+          class="mx-auto flex w-full max-w-2xl flex-wrap items-center justify-center gap-1 rounded-3xl border border-stone-200 bg-white/80 px-2 py-2 shadow-lg shadow-stone-200/70 backdrop-blur sm:w-fit sm:rounded-full sm:px-3"
           aria-label="Page sections"
         >
           <a
             v-for="link in navLinks"
             :key="link.href"
             :href="link.href"
-            class="rounded-full px-2.5 py-1.5 text-xs text-zinc-300 transition hover:bg-zinc-800 hover:text-zinc-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 sm:px-3 sm:text-sm"
+            class="rounded-full px-2.5 py-1.5 text-xs text-stone-600 transition hover:bg-stone-100 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 sm:px-3 sm:text-sm"
           >
             {{ link.label }}
           </a>
         </nav>
       </header>
 
-      <section id="about" class="grid items-center gap-8 rounded-3xl border border-zinc-800 bg-zinc-900/70 p-8 shadow-xl shadow-black/30 backdrop-blur md:grid-cols-[1.3fr_1fr] md:p-12">
+      <section id="about" class="grid items-center gap-8 rounded-3xl border border-stone-200 bg-white/80 p-8 shadow-xl shadow-stone-200/70 backdrop-blur md:grid-cols-[1.3fr_1fr] md:p-12">
         <div class="space-y-6">
-          <p class="text-sm font-medium uppercase tracking-[0.2em] text-emerald-300">Frontend Engineer</p>
+          <p class="text-sm font-medium uppercase tracking-[0.2em] text-amber-700">Frontend Engineer</p>
           <h1 class="text-4xl font-bold leading-tight text-balance md:text-6xl">Ivan Angjelkoski</h1>
-          <p class="max-w-2xl text-base leading-relaxed text-zinc-300 md:text-lg">
+          <p class="max-w-2xl text-base leading-relaxed text-stone-600 md:text-lg">
             I am a Frontend Developer at Injective Labs, focused on building polished,
             high-performance product experiences for modern web and Web3 users. I have spent
             3 years shipping frontend features and interfaces for crypto-native products, and I am
@@ -86,20 +86,20 @@ const navLinks = [
           <div class="flex flex-wrap gap-3">
             <a
               href="#projects"
-              class="rounded-full bg-emerald-300 px-5 py-2.5 text-sm font-semibold text-zinc-950 transition hover:-translate-y-0.5 hover:bg-emerald-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-100"
+              class="rounded-full bg-stone-900 px-5 py-2.5 text-sm font-semibold text-stone-50 transition hover:-translate-y-0.5 hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-300"
             >
               View Projects
             </a>
             <a
               href="#contact"
-              class="rounded-full border border-zinc-700 px-5 py-2.5 text-sm font-semibold text-zinc-100 transition hover:-translate-y-0.5 hover:border-zinc-500 hover:bg-zinc-800/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-200"
+              class="rounded-full border border-stone-300 bg-white/80 px-5 py-2.5 text-sm font-semibold text-stone-700 transition hover:-translate-y-0.5 hover:border-stone-400 hover:bg-stone-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-200"
             >
               Contact Me
             </a>
           </div>
         </div>
 
-        <div class="mx-auto w-fit rounded-3xl border border-zinc-800 bg-zinc-900/70 p-4 shadow-lg shadow-black/30">
+        <div class="mx-auto w-fit rounded-3xl border border-stone-200 bg-white/80 p-4 shadow-lg shadow-stone-200/70">
           <img
             src="/ivan_angjelkoski.jpeg"
             alt="Portrait of Ivan Angjelkoski"
@@ -110,7 +110,7 @@ const navLinks = [
 
       <section id="skills" class="mt-16 space-y-6">
         <h2 class="text-2xl font-semibold md:text-3xl">Skills & Technologies</h2>
-        <p class="max-w-3xl text-zinc-300">
+        <p class="max-w-3xl text-stone-600">
           A practical frontend toolkit for building robust web apps, full-stack services, and
           blockchain-integrated products.
         </p>
@@ -118,7 +118,7 @@ const navLinks = [
           <span
             v-for="skill in skills"
             :key="skill"
-            class="rounded-full border border-zinc-700 bg-zinc-900/80 px-4 py-2 text-sm font-medium text-zinc-100 shadow-md shadow-black/20"
+            class="rounded-full border border-stone-200 bg-white px-4 py-2 text-sm font-medium text-stone-700 shadow-md shadow-stone-200/60"
           >
             {{ skill }}
           </span>
@@ -127,12 +127,12 @@ const navLinks = [
 
       <section id="experience" class="mt-16 space-y-6">
         <h2 class="text-2xl font-semibold md:text-3xl">Experience</h2>
-        <article class="rounded-3xl border border-zinc-800 bg-zinc-900/70 p-7 shadow-xl shadow-black/25 transition duration-300 hover:-translate-y-1 hover:border-zinc-700">
+        <article class="rounded-3xl border border-stone-200 bg-white/80 p-7 shadow-xl shadow-stone-200/70 transition duration-300 hover:-translate-y-1 hover:border-stone-300">
           <div class="flex flex-wrap items-baseline justify-between gap-3">
-            <h3 class="text-xl font-semibold text-zinc-50">Injective Labs — Frontend Developer</h3>
-            <p class="text-sm font-medium text-emerald-300">2022 — Present · 3 years</p>
+            <h3 class="text-xl font-semibold text-stone-900">Injective Labs — Frontend Developer</h3>
+            <p class="text-sm font-medium text-amber-700">2022 — Present · 3 years</p>
           </div>
-          <ul class="mt-5 list-disc space-y-2 pl-5 text-zinc-300">
+          <ul class="mt-5 list-disc space-y-2 pl-5 text-stone-600">
             <li>Delivering production-grade UI for fast-moving trading and DeFi-focused workflows.</li>
             <li>Collaborating with product, design, and blockchain teams to ship clear and reliable transaction experiences.</li>
             <li>Improving frontend performance and maintainability using reusable architecture and typed development practices.</li>
@@ -146,15 +146,15 @@ const navLinks = [
           <article
             v-for="project in highlights"
             :key="project.name"
-            class="rounded-3xl border border-zinc-800 bg-zinc-900/70 p-6 shadow-xl shadow-black/20 transition duration-300 hover:-translate-y-1 hover:border-zinc-700"
+            class="rounded-3xl border border-stone-200 bg-white/80 p-6 shadow-xl shadow-stone-200/60 transition duration-300 hover:-translate-y-1 hover:border-stone-300"
           >
             <h3 class="text-lg font-semibold">{{ project.name }}</h3>
-            <p class="mt-3 text-sm leading-relaxed text-zinc-300">{{ project.description }}</p>
+            <p class="mt-3 text-sm leading-relaxed text-stone-600">{{ project.description }}</p>
             <div class="mt-4 flex flex-wrap gap-2">
               <span
                 v-for="tech in project.stack"
                 :key="tech"
-                class="rounded-full bg-zinc-800 px-3 py-1 text-xs font-medium text-zinc-200"
+                class="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-600"
               >
                 {{ tech }}
               </span>
@@ -163,16 +163,16 @@ const navLinks = [
         </div>
       </section>
 
-      <section id="contact" class="mt-16 rounded-3xl border border-zinc-800 bg-zinc-900/70 p-8 text-center shadow-xl shadow-black/25">
+      <section id="contact" class="mt-16 rounded-3xl border border-stone-200 bg-white/80 p-8 text-center shadow-xl shadow-stone-200/70">
         <h2 class="text-2xl font-semibold md:text-3xl">Let’s build something great</h2>
-        <p class="mx-auto mt-3 max-w-2xl text-zinc-300">
+        <p class="mx-auto mt-3 max-w-2xl text-stone-600">
           Open to collaborating on ambitious frontend and Web3 products.
           Feel free to reach out for opportunities, consulting, or partnerships.
         </p>
         <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
           <a
             href="mailto:ivan@example.com"
-            class="rounded-full bg-emerald-300 px-5 py-2.5 text-sm font-semibold text-zinc-950 transition hover:-translate-y-0.5 hover:bg-emerald-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-100"
+            class="rounded-full bg-stone-900 px-5 py-2.5 text-sm font-semibold text-stone-50 transition hover:-translate-y-0.5 hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-300"
           >
             Email Me
           </a>
@@ -180,7 +180,7 @@ const navLinks = [
             href="https://github.com"
             target="_blank"
             rel="noreferrer"
-            class="rounded-full border border-zinc-700 px-5 py-2.5 text-sm font-semibold text-zinc-100 transition hover:-translate-y-0.5 hover:border-zinc-500 hover:bg-zinc-800/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-200"
+            class="rounded-full border border-stone-300 bg-white/80 px-5 py-2.5 text-sm font-semibold text-stone-700 transition hover:-translate-y-0.5 hover:border-stone-400 hover:bg-stone-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-200"
           >
             GitHub
           </a>
@@ -188,7 +188,7 @@ const navLinks = [
             href="https://linkedin.com"
             target="_blank"
             rel="noreferrer"
-            class="rounded-full border border-zinc-700 px-5 py-2.5 text-sm font-semibold text-zinc-100 transition hover:-translate-y-0.5 hover:border-zinc-500 hover:bg-zinc-800/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-200"
+            class="rounded-full border border-stone-300 bg-white/80 px-5 py-2.5 text-sm font-semibold text-stone-700 transition hover:-translate-y-0.5 hover:border-stone-400 hover:bg-stone-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-200"
           >
             LinkedIn
           </a>


### PR DESCRIPTION
### Motivation
- Move the site from a dark theme to a bright, Anthropic-inspired light aesthetic with warm, muted accents and softened surfaces.
- Preserve content and layout while refreshing the palette, shadows, and surface treatments to improve readability in light mode.

### Description
- Switch global base styles in `app/assets/css/main.css` to light defaults by applying `bg-stone-50 text-stone-900 antialiased` to the `body` element.
- Update `app/pages/index.vue` to replace dark Tailwind utility classes with light equivalents (stone/white surfaces, amber/rose accents, softer borders and shadows, adjusted blob positions and colors, and updated button/label colors) while keeping the existing markup and layout intact.
- Add `node-compile-cache` to `.gitignore` to avoid checking in the local compile cache.

### Testing
- Started the dev server with `pnpm dev --host 0.0.0.0 --port 3000`, and Nuxt/Vite/Nitro completed their build successfully as shown in the log output.
- Ran an automated Playwright script that navigated to `http://localhost:3000` and captured a full-page screenshot at `artifacts/anthropic-light-home.png`, and the screenshot run completed successfully.
- No unit or integration test suites were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698688bb4f2883338d7702740d86fa67)