### PR TITLE
Redesign homepage with cyberpunk styling and responsive tweaks

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,5 +1,18 @@
+@import url("https://fonts.googleapis.com/css2?family=Share+Tech+Mono&family=Space+Grotesk:wght@400;500;600;700&display=swap");
 @import "tailwindcss";
 
 body {
-  @apply bg-stone-50 text-stone-900 antialiased;
+  font-family: "Space Grotesk", "Share Tech Mono", system-ui, sans-serif;
+  @apply bg-[#050507] text-slate-100 antialiased;
+}
+
+h1,
+h2,
+h3 {
+  font-family: "Share Tech Mono", "Space Grotesk", system-ui, sans-serif;
+}
+
+::selection {
+  background: rgba(255, 108, 0, 0.35);
+  color: #fff;
 }

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -52,32 +52,52 @@ const navLinks = [
 </script>
 
 <template>
-  <div class="relative overflow-x-clip bg-stone-50 text-stone-900">
-    <div class="pointer-events-none absolute -left-32 top-6 h-72 w-72 rounded-full bg-amber-200/40 blur-3xl" />
-    <div class="pointer-events-none absolute -right-32 top-56 h-72 w-72 rounded-full bg-rose-200/40 blur-3xl" />
+  <div class="relative overflow-hidden bg-[#050507] text-slate-100">
+    <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,108,0,0.15),_transparent_55%)]" />
+    <div class="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,_rgba(255,255,255,0.06)_1px,_transparent_1px),linear-gradient(to_bottom,_rgba(255,255,255,0.06)_1px,_transparent_1px)] bg-[size:120px_120px] opacity-20" />
+    <div class="pointer-events-none absolute -left-32 top-16 h-64 w-64 rounded-full bg-fuchsia-500/20 blur-[140px]" />
+    <div class="pointer-events-none absolute -right-32 top-72 h-64 w-64 rounded-full bg-cyan-400/20 blur-[140px]" />
 
-    <div class="mx-auto min-h-screen w-full max-w-6xl px-6 pb-20 pt-8 md:px-10">
+    <div class="relative mx-auto min-h-screen w-full max-w-6xl px-6 pb-24 pt-8 md:px-10">
       <header class="sticky top-4 z-20 mb-14">
         <nav
-          class="mx-auto flex w-full max-w-2xl flex-wrap items-center justify-center gap-1 rounded-3xl border border-stone-200 bg-white/80 px-2 py-2 shadow-lg shadow-stone-200/70 backdrop-blur sm:w-fit sm:rounded-full sm:px-3"
+          class="mx-auto flex w-full flex-wrap items-center justify-between gap-3 rounded-2xl border border-white/10 bg-black/60 px-4 py-3 shadow-[0_0_24px_rgba(255,108,0,0.15)] backdrop-blur sm:w-fit"
           aria-label="Page sections"
         >
-          <a
-            v-for="link in navLinks"
-            :key="link.href"
-            :href="link.href"
-            class="rounded-full px-2.5 py-1.5 text-xs text-stone-600 transition hover:bg-stone-100 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300 sm:px-3 sm:text-sm"
-          >
-            {{ link.label }}
-          </a>
+          <div class="flex items-center gap-2 text-sm font-semibold uppercase tracking-[0.3em] text-cyan-200">
+            <span class="text-orange-400">&lt;dev/&gt;</span>
+            <span class="hidden sm:inline">Ivan</span>
+          </div>
+          <div class="flex flex-wrap items-center gap-2 text-[11px] uppercase tracking-[0.25em] text-slate-300">
+            <a
+              v-for="(link, index) in navLinks"
+              :key="link.href"
+              :href="link.href"
+              class="rounded-full border border-transparent px-3 py-1 transition hover:border-orange-400/60 hover:text-orange-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
+            >
+              {{ String(index + 1).padStart(2, "0") }} // {{ link.label }}
+            </a>
+          </div>
         </nav>
       </header>
 
-      <section id="about" class="grid items-center gap-8 rounded-3xl border border-stone-200 bg-white/80 p-8 shadow-xl shadow-stone-200/70 backdrop-blur md:grid-cols-[1.3fr_1fr] md:p-12">
+      <section
+        id="about"
+        class="grid items-center gap-10 rounded-3xl border border-white/10 bg-black/70 p-8 shadow-[0_0_35px_rgba(0,255,255,0.12)] backdrop-blur md:grid-cols-[1.2fr_1fr] md:p-12"
+      >
         <div class="space-y-6">
-          <p class="text-sm font-medium uppercase tracking-[0.2em] text-amber-700">Frontend Engineer</p>
-          <h1 class="text-4xl font-bold leading-tight text-balance md:text-6xl">Ivan Angjelkoski</h1>
-          <p class="max-w-2xl text-base leading-relaxed text-stone-600 md:text-lg">
+          <div class="flex flex-wrap items-center gap-3">
+            <span class="rounded-full border border-orange-500/40 bg-orange-500/10 px-4 py-1 text-xs uppercase tracking-[0.3em] text-orange-300">
+              System Status: Online
+            </span>
+            <span class="rounded-full border border-cyan-500/40 bg-cyan-500/10 px-4 py-1 text-xs uppercase tracking-[0.3em] text-cyan-200">
+              Frontend Engineer
+            </span>
+          </div>
+          <h1 class="text-4xl font-semibold leading-tight text-white md:text-6xl">
+            Hello World — I am <span class="text-orange-400">Ivan_Dev</span>
+          </h1>
+          <p class="max-w-2xl text-base leading-relaxed text-slate-300 md:text-lg">
             I am a Frontend Developer at Injective Labs, focused on building polished,
             high-performance product experiences for modern web and Web3 users. I have spent
             3 years shipping frontend features and interfaces for crypto-native products, and I am
@@ -86,31 +106,57 @@ const navLinks = [
           <div class="flex flex-wrap gap-3">
             <a
               href="#projects"
-              class="rounded-full bg-stone-900 px-5 py-2.5 text-sm font-semibold text-stone-50 transition hover:-translate-y-0.5 hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-300"
+              class="rounded-full border border-orange-500/60 bg-orange-500/20 px-6 py-2.5 text-sm font-semibold uppercase tracking-[0.2em] text-orange-200 transition hover:-translate-y-0.5 hover:bg-orange-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
             >
               View Projects
             </a>
             <a
               href="#contact"
-              class="rounded-full border border-stone-300 bg-white/80 px-5 py-2.5 text-sm font-semibold text-stone-700 transition hover:-translate-y-0.5 hover:border-stone-400 hover:bg-stone-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-200"
+              class="rounded-full border border-cyan-400/60 bg-cyan-400/10 px-6 py-2.5 text-sm font-semibold uppercase tracking-[0.2em] text-cyan-100 transition hover:-translate-y-0.5 hover:bg-cyan-400/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
             >
-              Contact Me
+              Initiate Contact
             </a>
           </div>
         </div>
 
-        <div class="mx-auto w-fit rounded-3xl border border-stone-200 bg-white/80 p-4 shadow-lg shadow-stone-200/70">
-          <img
-            src="/ivan_angjelkoski.jpeg"
-            alt="Portrait of Ivan Angjelkoski"
-            class="h-72 w-64 rounded-2xl object-cover object-top md:h-80 md:w-72"
-          >
+        <div class="relative mx-auto w-full max-w-sm rounded-3xl border border-orange-500/30 bg-black/70 p-6 shadow-[0_0_30px_rgba(255,108,0,0.2)]">
+          <div class="flex items-center justify-between text-xs uppercase tracking-[0.3em] text-orange-300">
+            <span>root@portfolio:~</span>
+            <span class="text-cyan-200">zsh</span>
+          </div>
+          <div class="mt-4 space-y-3 text-sm text-slate-300">
+            <p><span class="text-cyan-300">&gt; initializing core...</span></p>
+            <p><span class="text-emerald-300">&gt; loading modules: [HTML, CSS, JS]</span></p>
+            <p><span class="text-emerald-300">&gt; connecting to database...</span></p>
+            <p><span class="text-orange-300">&gt; success.</span></p>
+          </div>
+          <div v-pre class="mt-5 rounded-2xl border border-white/10 bg-black/80 p-4 text-xs text-slate-200">
+            <p>const developer = {{</p>
+            <p class="ml-4">name: "Ivan Angjelkoski",</p>
+            <p class="ml-4">location: "North Macedonia",</p>
+            <p class="ml-4">coffeeLevel: "Critical",</p>
+            <p class="ml-4">skills: ["React", "Nuxt", "Web3"],</p>
+            <p>}};</p>
+          </div>
+          <div class="mt-6 flex items-center gap-4">
+            <div class="h-16 w-16 overflow-hidden rounded-2xl border border-cyan-400/40">
+              <img
+                src="/ivan_angjelkoski.jpeg"
+                alt="Portrait of Ivan Angjelkoski"
+                class="h-full w-full object-cover object-top"
+              >
+            </div>
+            <div class="text-xs text-slate-300">
+              <p class="uppercase tracking-[0.3em] text-cyan-200">Identity Verified</p>
+              <p class="text-sm text-white">Frontend Developer</p>
+            </div>
+          </div>
         </div>
       </section>
 
       <section id="skills" class="mt-16 space-y-6">
-        <h2 class="text-2xl font-semibold md:text-3xl">Skills & Technologies</h2>
-        <p class="max-w-3xl text-stone-600">
+        <h2 class="text-2xl font-semibold text-white md:text-3xl">Skills & Technologies</h2>
+        <p class="max-w-3xl text-slate-300">
           A practical frontend toolkit for building robust web apps, full-stack services, and
           blockchain-integrated products.
         </p>
@@ -118,7 +164,7 @@ const navLinks = [
           <span
             v-for="skill in skills"
             :key="skill"
-            class="rounded-full border border-stone-200 bg-white px-4 py-2 text-sm font-medium text-stone-700 shadow-md shadow-stone-200/60"
+            class="rounded-full border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium uppercase tracking-[0.2em] text-cyan-100 shadow-[0_0_18px_rgba(0,255,255,0.1)]"
           >
             {{ skill }}
           </span>
@@ -126,13 +172,13 @@ const navLinks = [
       </section>
 
       <section id="experience" class="mt-16 space-y-6">
-        <h2 class="text-2xl font-semibold md:text-3xl">Experience</h2>
-        <article class="rounded-3xl border border-stone-200 bg-white/80 p-7 shadow-xl shadow-stone-200/70 transition duration-300 hover:-translate-y-1 hover:border-stone-300">
+        <h2 class="text-2xl font-semibold text-white md:text-3xl">Experience</h2>
+        <article class="rounded-3xl border border-white/10 bg-black/70 p-7 shadow-[0_0_30px_rgba(0,255,255,0.12)] transition duration-300 hover:-translate-y-1 hover:border-cyan-400/50">
           <div class="flex flex-wrap items-baseline justify-between gap-3">
-            <h3 class="text-xl font-semibold text-stone-900">Injective Labs — Frontend Developer</h3>
-            <p class="text-sm font-medium text-amber-700">2022 — Present · 3 years</p>
+            <h3 class="text-xl font-semibold text-white">Injective Labs — Frontend Developer</h3>
+            <p class="text-sm font-medium uppercase tracking-[0.3em] text-orange-300">2022 — Present · 3 years</p>
           </div>
-          <ul class="mt-5 list-disc space-y-2 pl-5 text-stone-600">
+          <ul class="mt-5 list-disc space-y-2 pl-5 text-slate-300">
             <li>Delivering production-grade UI for fast-moving trading and DeFi-focused workflows.</li>
             <li>Collaborating with product, design, and blockchain teams to ship clear and reliable transaction experiences.</li>
             <li>Improving frontend performance and maintainability using reusable architecture and typed development practices.</li>
@@ -141,20 +187,20 @@ const navLinks = [
       </section>
 
       <section id="projects" class="mt-16 space-y-6">
-        <h2 class="text-2xl font-semibold md:text-3xl">Selected Projects</h2>
+        <h2 class="text-2xl font-semibold text-white md:text-3xl">Selected Projects</h2>
         <div class="grid gap-5 md:grid-cols-3">
           <article
             v-for="project in highlights"
             :key="project.name"
-            class="rounded-3xl border border-stone-200 bg-white/80 p-6 shadow-xl shadow-stone-200/60 transition duration-300 hover:-translate-y-1 hover:border-stone-300"
+            class="rounded-3xl border border-white/10 bg-black/70 p-6 shadow-[0_0_25px_rgba(255,108,0,0.12)] transition duration-300 hover:-translate-y-1 hover:border-orange-400/50"
           >
-            <h3 class="text-lg font-semibold">{{ project.name }}</h3>
-            <p class="mt-3 text-sm leading-relaxed text-stone-600">{{ project.description }}</p>
+            <h3 class="text-lg font-semibold text-white">{{ project.name }}</h3>
+            <p class="mt-3 text-sm leading-relaxed text-slate-300">{{ project.description }}</p>
             <div class="mt-4 flex flex-wrap gap-2">
               <span
                 v-for="tech in project.stack"
                 :key="tech"
-                class="rounded-full bg-stone-100 px-3 py-1 text-xs font-medium text-stone-600"
+                class="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs font-medium uppercase tracking-[0.2em] text-orange-200"
               >
                 {{ tech }}
               </span>
@@ -163,16 +209,16 @@ const navLinks = [
         </div>
       </section>
 
-      <section id="contact" class="mt-16 rounded-3xl border border-stone-200 bg-white/80 p-8 text-center shadow-xl shadow-stone-200/70">
-        <h2 class="text-2xl font-semibold md:text-3xl">Let’s build something great</h2>
-        <p class="mx-auto mt-3 max-w-2xl text-stone-600">
+      <section id="contact" class="mt-16 rounded-3xl border border-white/10 bg-black/70 p-8 text-center shadow-[0_0_35px_rgba(255,108,0,0.2)]">
+        <h2 class="text-2xl font-semibold text-white md:text-3xl">Let’s build something great</h2>
+        <p class="mx-auto mt-3 max-w-2xl text-slate-300">
           Open to collaborating on ambitious frontend and Web3 products.
           Feel free to reach out for opportunities, consulting, or partnerships.
         </p>
         <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
           <a
             href="mailto:ivan@example.com"
-            class="rounded-full bg-stone-900 px-5 py-2.5 text-sm font-semibold text-stone-50 transition hover:-translate-y-0.5 hover:bg-stone-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-300"
+            class="rounded-full border border-orange-500/60 bg-orange-500/20 px-5 py-2.5 text-sm font-semibold uppercase tracking-[0.2em] text-orange-100 transition hover:-translate-y-0.5 hover:bg-orange-500/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-orange-400"
           >
             Email Me
           </a>
@@ -180,7 +226,7 @@ const navLinks = [
             href="https://github.com"
             target="_blank"
             rel="noreferrer"
-            class="rounded-full border border-stone-300 bg-white/80 px-5 py-2.5 text-sm font-semibold text-stone-700 transition hover:-translate-y-0.5 hover:border-stone-400 hover:bg-stone-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-200"
+            class="rounded-full border border-cyan-400/60 bg-cyan-400/10 px-5 py-2.5 text-sm font-semibold uppercase tracking-[0.2em] text-cyan-100 transition hover:-translate-y-0.5 hover:bg-cyan-400/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
           >
             GitHub
           </a>
@@ -188,7 +234,7 @@ const navLinks = [
             href="https://linkedin.com"
             target="_blank"
             rel="noreferrer"
-            class="rounded-full border border-stone-300 bg-white/80 px-5 py-2.5 text-sm font-semibold text-stone-700 transition hover:-translate-y-0.5 hover:border-stone-400 hover:bg-stone-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-200"
+            class="rounded-full border border-cyan-400/60 bg-cyan-400/10 px-5 py-2.5 text-sm font-semibold uppercase tracking-[0.2em] text-cyan-100 transition hover:-translate-y-0.5 hover:bg-cyan-400/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300"
           >
             LinkedIn
           </a>


### PR DESCRIPTION
### Motivation
- Move the portfolio from a light, neutral look to a dark cyberpunk aesthetic with neon accents and a terminal-like hero to better match the requested reference image. 
- Keep the layout fully responsive and preserve the existing content structure and navigation for mobile-first use.

### Description
- Restyled the homepage by replacing the light theme with a dark neon design in `app/pages/index.vue`, including radial/blurred neon backgrounds, a terminal-style hero panel, neon-accented buttons, and updated card treatments. 
- Updated global typography and selection styles in `app/assets/css/main.css` by adding Google fonts (`Share Tech Mono`, `Space Grotesk`), setting dark background colors, and adding `::selection` highlighting. 
- Improved the header/navigation for the new theme with compact, numbered links and a logo accent, and added `v-pre` to the terminal code block to avoid Vue interpolation. 
- Kept existing content (sections, data arrays) intact while adjusting colors, spacing, and shadow/glow utilities to match the new aesthetic.

### Testing
- Launched the dev server with `pnpm dev --host 0.0.0.0 --port 3000`, which started successfully (CSS import ordering produced warnings that were corrected). 
- Captured visual verification images by running a Playwright script to take screenshots at desktop and mobile viewports, which produced `artifacts/cyberpunk-desktop.png` and `artifacts/cyberpunk-mobile.png` successfully after re-running the script in Python (an initial JS-script attempt failed with a syntax error). 
- No unit or integration test suites were applicable for these visual changes and thus were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988c3cad1f48333a89ac9d459a49303)