### PR TITLE
Redesign portfolio with editorial UI and robust responsive nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is my personal portfolio website featuring:
 - Skills and technology showcase
 - Selected project highlights
 - Contact information
-- Dark/light mode support
+- Premium editorial visual system
 - Fully responsive design
 
 ## Tech Stack

--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -1,35 +1,21 @@
-@import url("https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;800;900&family=Share+Tech+Mono&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Manrope:wght@400;500;600;700&display=swap");
 @import "tailwindcss";
-@custom-variant dark (&:where(.dark, .dark *));
 
 :root {
-  --cyber-white: #f5f5f5;
-  --cyber-white-2: #ffffff;
-  --cyber-white-3: #ebebeb;
-  --cyber-yellow: #ffcc00;
-  --cyber-yellow-light: #ffdd33;
-  --cyber-yellow-glow: #e6b800;
-  --cyber-gray: #cccccc;
-  --cyber-gray-dark: #888888;
-  --cyber-text: #1a1a1a;
-  --cyber-text-muted: #555555;
-  --cyber-bg: #f5f5f5;
-  --cyber-bg-secondary: #ebebeb;
-}
-
-.dark {
-  --cyber-white: #0a0a0a;
-  --cyber-white-2: #111111;
-  --cyber-white-3: #1a1a1a;
-  --cyber-yellow: #ffcc00;
-  --cyber-yellow-light: #ffdd33;
-  --cyber-yellow-glow: #e6b800;
-  --cyber-gray: #333333;
-  --cyber-gray-dark: #666666;
-  --cyber-text: #e5e5e5;
-  --cyber-text-muted: #999999;
-  --cyber-bg: #050505;
-  --cyber-bg-secondary: #0f0f0f;
+  --bg: #f7f3ee;
+  --bg-soft: #efe7dd;
+  --surface: #fffdfc;
+  --accent: #d8c3a5;
+  --accent-strong: #8c6f5a;
+  --text: #2f2a26;
+  --text-muted: #6e6258;
+  --border: #e6ddd3;
+  --shadow-soft: 0 18px 45px rgba(77, 56, 41, 0.08);
+  --shadow-card: 0 14px 36px rgba(77, 56, 41, 0.1);
+  --radius-card: 1.2rem;
+  --ease-standard: cubic-bezier(0.22, 1, 0.36, 1);
+  --dur-fast: 180ms;
+  --dur-mid: 320ms;
 }
 
 * {
@@ -41,157 +27,317 @@ html {
 }
 
 body {
-  font-family: "Share Tech Mono", monospace;
-  background-color: var(--cyber-bg);
-  color: var(--cyber-text);
-  background-image:
-    linear-gradient(rgba(255, 204, 0, 0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 204, 0, 0.05) 1px, transparent 1px);
-  background-size: 50px 50px;
-  background-position: center top;
+  margin: 0;
   min-height: 100vh;
-  transition: background-color 0.3s ease, color 0.3s ease;
+  font-family: "Manrope", "Helvetica Neue", Arial, sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+  background-image:
+    radial-gradient(circle at 14% -5%, rgba(216, 195, 165, 0.58), transparent 38%),
+    radial-gradient(circle at 88% 5%, rgba(191, 165, 138, 0.33), transparent 42%),
+    linear-gradient(180deg, rgba(255, 253, 252, 0.92), rgba(247, 243, 238, 1));
+  background-attachment: fixed;
 }
 
 body::before {
   content: "";
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 3px;
-  background: linear-gradient(90deg, transparent, var(--cyber-orange), transparent);
-  z-index: 9999;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(rgba(255, 255, 255, 0.15) 1px, transparent 1px);
+  background-size: 100% 3px;
+  mix-blend-mode: soft-light;
+  opacity: 0.2;
+  z-index: -1;
 }
 
-h1, h2, h3, h4, h5, h6 {
-  font-family: "Orbitron", sans-serif;
-  font-weight: 700;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-family: "Cormorant Garamond", Georgia, serif;
+  color: var(--text);
+  letter-spacing: 0.015em;
+}
+
+p {
+  margin: 0;
 }
 
 ::selection {
-  background: var(--cyber-yellow);
-  color: var(--cyber-white);
+  color: var(--text);
+  background: rgba(216, 195, 165, 0.58);
 }
 
-a {
-  transition: all 0.2s ease;
+a,
+button {
+  transition:
+    color var(--dur-fast) var(--ease-standard),
+    border-color var(--dur-fast) var(--ease-standard),
+    background-color var(--dur-fast) var(--ease-standard),
+    transform var(--dur-mid) var(--ease-standard),
+    box-shadow var(--dur-mid) var(--ease-standard),
+    opacity var(--dur-fast) var(--ease-standard);
 }
 
-a:hover {
-  color: var(--cyber-yellow);
-  text-shadow: 0 0 10px var(--cyber-yellow-light);
-}
-
-.cyber-glow {
-  text-shadow: 0 0 10px var(--cyber-yellow), 0 0 20px var(--cyber-yellow-light), 0 0 40px var(--cyber-yellow-glow);
-}
-
-.cyber-border {
-  border: 1px solid var(--cyber-yellow);
+.page-shell {
   position: relative;
+  isolation: isolate;
 }
 
-.cyber-border::before {
+.page-shell::before,
+.page-shell::after {
   content: "";
   position: absolute;
-  top: -1px;
-  left: -1px;
-  width: 10px;
-  height: 10px;
-  border-top: 2px solid var(--cyber-yellow);
-  border-left: 2px solid var(--cyber-yellow);
+  border-radius: 999px;
+  pointer-events: none;
+  filter: blur(28px);
+  z-index: -1;
 }
 
-.cyber-border::after {
+.page-shell::before {
+  top: 6rem;
+  right: -8rem;
+  width: 17rem;
+  height: 17rem;
+  background: rgba(216, 195, 165, 0.25);
+}
+
+.page-shell::after {
+  bottom: 8rem;
+  left: -8rem;
+  width: 14rem;
+  height: 14rem;
+  background: rgba(140, 111, 90, 0.15);
+}
+
+.section-shell {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-card);
+  background: color-mix(in srgb, var(--surface) 92%, white 8%);
+  box-shadow: var(--shadow-soft);
+}
+
+.editorial-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.69rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.editorial-label::before {
   content: "";
-  position: absolute;
-  bottom: -1px;
-  right: -1px;
-  width: 10px;
-  height: 10px;
-  border-bottom: 2px solid var(--cyber-yellow);
-  border-right: 2px solid var(--cyber-yellow);
+  width: 2rem;
+  height: 1px;
+  background: color-mix(in srgb, var(--accent-strong) 45%, transparent);
 }
 
-.scan-line {
+.section-title {
+  font-size: clamp(2rem, 4.8vw, 3.3rem);
+  line-height: 1.02;
+  font-weight: 600;
+}
+
+.section-heading {
+  font-size: clamp(1.9rem, 4vw, 2.7rem);
+  line-height: 1.08;
+  font-weight: 600;
+}
+
+.section-intro {
+  max-width: 41rem;
+  font-size: 1rem;
+  line-height: 1.82;
+  color: var(--text-muted);
+}
+
+.premium-card {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--surface) 96%, var(--bg-soft) 4%);
+  box-shadow: var(--shadow-card);
+}
+
+.muted-meta {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: color-mix(in srgb, var(--text-muted) 78%, var(--text) 22%);
+}
+
+.soft-divider {
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(90deg, transparent, var(--border), transparent);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.42rem;
+  border-radius: 999px;
+  padding: 0.72rem 1.38rem;
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.btn:focus-visible,
+.link-chip:focus-visible,
+.nav-link:focus-visible {
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(191, 165, 138, 0.3);
+}
+
+.btn-primary {
+  border-color: color-mix(in srgb, var(--accent-strong) 64%, transparent);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--accent) 82%, white 18%), color-mix(in srgb, var(--accent) 90%, var(--accent-strong) 10%));
+  color: var(--text);
+}
+
+.btn-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 24px rgba(140, 111, 90, 0.22);
+}
+
+.btn-secondary {
+  border-color: color-mix(in srgb, var(--accent-strong) 36%, transparent);
+  background: color-mix(in srgb, var(--surface) 70%, var(--bg-soft) 30%);
+  color: color-mix(in srgb, var(--text) 90%, var(--text-muted) 10%);
+}
+
+.btn-secondary:hover {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--accent-strong) 55%, transparent);
+  background: color-mix(in srgb, var(--surface) 64%, var(--accent) 36%);
+}
+
+.nav-link {
   position: relative;
-  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.45rem 0.25rem;
+  color: color-mix(in srgb, var(--text) 76%, var(--text-muted) 24%);
+  text-transform: uppercase;
+  letter-spacing: 0.13em;
+  font-size: 0.72rem;
+  font-weight: 600;
 }
 
-.scan-line::after {
+.nav-link::after {
   content: "";
   position: absolute;
-  top: 0;
   left: 0;
   right: 0;
-  height: 2px;
-  background: linear-gradient(90deg, transparent, var(--cyber-yellow), transparent);
-  animation: scan 3s linear infinite;
+  bottom: -0.15rem;
+  height: 1px;
+  background: var(--accent-strong);
+  transform-origin: left;
+  transform: scaleX(0);
+  transition: transform var(--dur-mid) var(--ease-standard);
 }
 
-@keyframes scan {
-  0% {
-    transform: translateY(-100%);
-    opacity: 0;
-  }
-  10% {
-    opacity: 1;
-  }
-  90% {
-    opacity: 1;
-  }
-  100% {
-    transform: translateY(100vh);
-    opacity: 0;
-  }
+.nav-link:hover {
+  color: var(--text);
 }
 
-.glitch {
+.nav-link:hover::after {
+  transform: scaleX(1);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent-strong) 22%, var(--border));
+  background: color-mix(in srgb, var(--surface) 86%, var(--bg-soft) 14%);
+  padding: 0.38rem 0.78rem;
+  font-size: 0.76rem;
+  color: color-mix(in srgb, var(--text-muted) 78%, var(--text) 22%);
+}
+
+.project-shell {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 1.05rem;
+  background: var(--surface);
+  box-shadow: 0 18px 38px rgba(73, 53, 38, 0.08);
+}
+
+.project-shell:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 24px 46px rgba(73, 53, 38, 0.13);
+}
+
+.media-frame {
   position: relative;
-  animation: glitch 1s linear infinite;
+  overflow: hidden;
+  border-radius: 0.88rem;
+  border: 1px solid color-mix(in srgb, var(--accent-strong) 20%, var(--border));
+  background:
+    radial-gradient(circle at 80% 20%, rgba(216, 195, 165, 0.45), transparent 42%),
+    linear-gradient(135deg, color-mix(in srgb, var(--bg-soft) 88%, white 12%), color-mix(in srgb, var(--surface) 78%, var(--bg-soft) 22%));
 }
 
-@keyframes glitch {
-  2%, 64% {
-    transform: translate(2px, 0) skew(0deg);
-  }
-  4%, 60% {
-    transform: translate(-2px, 0) skew(0deg);
-  }
-  62% {
-    transform: translate(0, 0) skew(5deg);
-  }
+.media-frame::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent 0%, rgba(255, 255, 255, 0.35) 35%, transparent 65%);
+  transform: translateX(-130%);
+  transition: transform 650ms var(--ease-standard);
 }
 
-.flicker {
-  animation: flicker 0.15s infinite;
+.project-shell:hover .media-frame::after {
+  transform: translateX(130%);
 }
 
-@keyframes flicker {
-  0% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.8;
-  }
-  100% {
-    opacity: 1;
-  }
+.link-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--accent-strong) 42%, var(--border));
+  background: color-mix(in srgb, var(--surface) 75%, var(--bg-soft) 25%);
+  padding: 0.46rem 0.82rem;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: color-mix(in srgb, var(--text-muted) 88%, var(--text) 12%);
 }
 
-.tech-grid {
-  background-image:
-    linear-gradient(rgba(255, 204, 0, 0.1) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 204, 0, 0.1) 1px, transparent 1px);
-  background-size: 20px 20px;
+.link-chip:hover {
+  color: var(--text);
+  border-color: color-mix(in srgb, var(--accent-strong) 58%, transparent);
+  background: color-mix(in srgb, var(--surface) 55%, var(--accent) 45%);
 }
 
-.gradient-text {
-  background: linear-gradient(135deg, var(--cyber-yellow) 0%, var(--cyber-yellow-light) 100%);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+.link-chip[aria-disabled="true"] {
+  opacity: 0.56;
+  cursor: not-allowed;
+}
+
+@media (max-width: 768px) {
+  .section-shell {
+    border-radius: 1rem;
+  }
+
+  .section-intro {
+    max-width: 100%;
+  }
+
+  .btn {
+    letter-spacing: 0.12em;
+    width: 100%;
+  }
 }

--- a/app/components/AboutSection.vue
+++ b/app/components/AboutSection.vue
@@ -1,75 +1,78 @@
 <template>
   <section
     id="about"
-    class="grid items-center gap-10 rounded-none border border-[#0077cc]/40 bg-[#ffffff] dark:bg-[#111111] p-8 md:grid-cols-[1.2fr_1fr] md:p-12 relative about-animate"
+    class="section-shell grid gap-10 p-7 sm:p-10 lg:grid-cols-[1.3fr_0.9fr] lg:gap-12 lg:p-12"
   >
-    <div class="absolute top-0 left-0 w-3 h-3 border-t-2 border-l-2 border-[#0077cc]" />
-    <div class="absolute top-0 right-0 w-3 h-3 border-t-2 border-r-2 border-[#0077cc]" />
-    <div class="absolute bottom-0 left-0 w-3 h-3 border-b-2 border-l-2 border-[#0077cc]" />
-    <div class="absolute bottom-0 right-0 w-3 h-3 border-b-2 border-r-2 border-[#0077cc]" />
-    
-    <div class="space-y-6">
-      <div class="flex flex-wrap items-center gap-3">
-        <span class="rounded-none border border-[#cccccc] dark:border-[#333333] bg-[#ebebeb] dark:bg-[#1a1a1a] px-4 py-1.5 text-xs font-medium font-['Orbitron'] uppercase tracking-wider text-[#555555] dark:text-[#999999]">
-          Frontend Developer
-        </span>
-      </div>
-      <h1 class="text-4xl font-bold font-['Orbitron'] leading-tight text-[#1a1a1a] dark:text-[#e5e5e5] md:text-5xl">
-        <span class="text-[#0077cc] cyber-glow">WEB</span>DEV<span class="text-[#0077cc]">_</span>
+    <div class="space-y-7">
+      <span class="editorial-label">Frontend Engineer</span>
+
+      <h1 class="section-title max-w-3xl">
+        Design-forward interfaces built with precision, clarity, and modern web craft.
       </h1>
-      <p class="max-w-2xl text-lg leading-relaxed text-[#555555] dark:text-[#999999] font-['Share_Tech_Mono']">
-        > I am a Frontend Developer at Injective Labs, focused on building polished,
-        high-performance product experiences for modern web and Web3 users.<br/><br/>
-        > 3 years shipping frontend features for crypto-native products<br/>
-        > Based in North Macedonia
+
+      <p class="section-intro">
+        I am Ivan Angjelkoski, a frontend developer at Injective Labs focused on premium product
+        experiences for web and Web3. For the past three years, I have shipped high-impact
+        features where interaction quality, reliability, and performance all matter.
       </p>
-      <div class="flex flex-wrap gap-3">
-        <a
-          href="#projects"
-          class="rounded-none border border-[#0077cc] bg-[#0077cc] px-6 py-2.5 text-sm font-semibold font-['Orbitron'] text-[#ffffff] transition hover:bg-[#0099e6] hover:shadow-[0_0_20px_#0077cc] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]"
-        >
-          VIEW_PROJECTS
-        </a>
-        <a
-          href="#contact"
-          class="rounded-none border border-[#0077cc]/50 bg-transparent px-6 py-2.5 text-sm font-semibold font-['Orbitron'] text-[#0077cc] transition hover:bg-[#0077cc]/10 hover:shadow-[0_0_10px_#0077cc] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]"
-        >
-          GET_IN_TOUCH
-        </a>
+
+      <div class="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+        <a href="#projects" class="btn btn-primary">View Projects</a>
+        <a href="#contact" class="btn btn-secondary">Start a Conversation</a>
+      </div>
+
+      <div class="grid gap-4 pt-2 sm:grid-cols-3">
+        <article class="premium-card p-4">
+          <p class="muted-meta">Experience</p>
+          <p class="mt-2 font-['Cormorant_Garamond'] text-3xl font-semibold text-[var(--text)]">3+</p>
+          <p class="mt-1 text-sm text-[var(--text-muted)]">Years delivering production UI</p>
+        </article>
+        <article class="premium-card p-4">
+          <p class="muted-meta">Specialty</p>
+          <p class="mt-2 font-['Cormorant_Garamond'] text-2xl font-semibold text-[var(--text)]">Frontend Systems</p>
+          <p class="mt-1 text-sm text-[var(--text-muted)]">Architecture and polish</p>
+        </article>
+        <article class="premium-card p-4">
+          <p class="muted-meta">Based In</p>
+          <p class="mt-2 font-['Cormorant_Garamond'] text-2xl font-semibold text-[var(--text)]">North Macedonia</p>
+          <p class="mt-1 text-sm text-[var(--text-muted)]">Collaborating globally</p>
+        </article>
       </div>
     </div>
 
-    <div class="relative mx-auto w-full max-w-sm rounded-none border border-[#0077cc]/40 bg-[#f5f5f5] dark:bg-[#0f0f0f] p-6">
-      <div class="flex items-center justify-between text-xs font-['Orbitron'] uppercase tracking-wider text-[#555555] dark:text-[#999999]">
-        <span>> Quick Profile</span>
-        <span class="text-[#0077cc]">Details</span>
+    <aside class="premium-card flex flex-col gap-5 p-6 sm:p-7">
+      <div class="media-frame h-[20.5rem] w-full overflow-hidden">
+        <img
+          src="/ivan_angjelkoski.jpeg"
+          alt="Portrait of Ivan Angjelkoski"
+          class="h-full w-full object-cover object-top"
+        >
       </div>
-      <div class="mt-6 space-y-3 text-sm font-['Share_Tech_Mono'] text-[#555555] dark:text-[#999999]">
-        <p><strong class="text-[#0077cc]">Name:</strong> Ivan Angjelkoski</p>
-        <p><strong class="text-[#0077cc]">Location:</strong> North Macedonia</p>
-        <p><strong class="text-[#0077cc]">Experience:</strong> 3+ Years</p>
-        <p><strong class="text-[#0077cc]">Role:</strong> Frontend Developer</p>
-      </div>
-      <div class="mt-6 rounded-none border border-[#0077cc]/30 bg-[#ffffff] dark:bg-[#111111] p-4 text-xs font-['Share_Tech_Mono'] text-[#555555] dark:text-[#999999]">
-        <p class="font-['Orbitron'] font-semibold text-[#0077cc] mb-2">> Core Technologies</p>
-        <p class="ml-4">- React / Next.js</p>
-        <p class="ml-4">- Vue / Nuxt</p>
-        <p class="ml-4">- TypeScript</p>
-        <p class="ml-4">- Web3 / Cosmos</p>
-      </div>
-      <div class="mt-6 flex items-center gap-4">
-        <div class="h-16 w-16 overflow-hidden rounded-none border border-[#0077cc]/30 bg-[#ebebeb] dark:bg-[#1a1a1a]">
-          <img
-            src="/ivan_angjelkoski.jpeg"
-            alt="Portrait of Ivan Angjelkoski"
-            class="h-full w-full object-cover object-top grayscale hover:grayscale-0 transition"
-          >
-        </div>
+
+      <div class="space-y-4">
         <div>
-          <p class="text-sm font-['Orbitron'] font-semibold text-[#1a1a1a] dark:text-[#e5e5e5]">Ivan Angjelkoski</p>
-          <p class="text-xs font-['Share_Tech_Mono'] text-[#555555] dark:text-[#999999]">Frontend Developer</p>
+          <p class="muted-meta">Profile</p>
+          <h2 class="mt-1 font-['Cormorant_Garamond'] text-3xl font-semibold text-[var(--text)]">Ivan Angjelkoski</h2>
+          <p class="mt-1 text-sm text-[var(--text-muted)]">Frontend Developer at Injective Labs</p>
         </div>
+
+        <div class="soft-divider" />
+
+        <dl class="space-y-3 text-sm text-[var(--text-muted)]">
+          <div class="flex items-center justify-between gap-3">
+            <dt class="muted-meta">Focus</dt>
+            <dd>Product-grade web and Web3 UX</dd>
+          </div>
+          <div class="flex items-center justify-between gap-3">
+            <dt class="muted-meta">Core Stack</dt>
+            <dd>Vue, Nuxt, React, TypeScript</dd>
+          </div>
+          <div class="flex items-center justify-between gap-3">
+            <dt class="muted-meta">Collaboration</dt>
+            <dd>Product, design, and protocol teams</dd>
+          </div>
+        </dl>
       </div>
-    </div>
+    </aside>
   </section>
 </template>

--- a/app/components/AppFooter.vue
+++ b/app/components/AppFooter.vue
@@ -1,7 +1,22 @@
 <template>
-  <footer class="mt-24 border-t border-[#0077cc]/20 pt-8 text-center footer-animate">
-    <p class="text-sm font-['Share_Tech_Mono'] text-[#555555] dark:text-[#999999]">
-      <span class="text-[#0077cc]">></span> Built with Vue + Nuxt | © 2026 Ivan Angjelkoski
+  <footer class="footer-animate mt-20 space-y-6 pb-4">
+    <div class="soft-divider" />
+
+    <div class="flex flex-col items-center justify-between gap-4 text-center sm:flex-row sm:text-left">
+      <div>
+        <p class="font-['Cormorant_Garamond'] text-2xl font-semibold text-[var(--text)]">Ivan Angjelkoski</p>
+        <p class="text-sm text-[var(--text-muted)]">Frontend engineer crafting refined product experiences.</p>
+      </div>
+
+      <div class="flex flex-wrap items-center justify-center gap-4 text-[0.72rem] font-semibold uppercase tracking-[0.14em] text-[var(--text-muted)]">
+        <a href="#home" class="nav-link !py-0">Home</a>
+        <a href="#projects" class="nav-link !py-0">Projects</a>
+        <a href="#contact" class="nav-link !py-0">Contact</a>
+      </div>
+    </div>
+
+    <p class="text-center text-xs uppercase tracking-[0.14em] text-[var(--text-muted)]">
+      © 2026 · Built with Nuxt and TypeScript
     </p>
   </footer>
 </template>

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -1,89 +1,120 @@
 <script setup lang="ts">
-defineProps<{
-  foo?: string;
-  bar: number;
-}>();
-
-const isMenuOpen = ref(false);
-const colorMode = useColorMode();
-
-const toggleTheme = () => {
-  colorMode.preference = colorMode.value === 'dark' ? 'light' : 'dark';
+type NavLink = {
+  label: string;
+  href: `#${string}`;
 };
 
-const navLinks = [
+const navLinks: NavLink[] = [
+  { label: "Home", href: "#home" },
   { label: "About", href: "#about" },
   { label: "Skills", href: "#skills" },
   { label: "Experience", href: "#experience" },
   { label: "Projects", href: "#projects" },
   { label: "Contact", href: "#contact" },
 ];
+
+const isMenuOpen = ref(false);
+const shouldRestoreFocus = ref(false);
+const menuButtonRef = ref<HTMLButtonElement | null>(null);
+const mobileMenuRef = ref<HTMLElement | null>(null);
+
+const openMenu = () => {
+  shouldRestoreFocus.value = true;
+  isMenuOpen.value = true;
+};
+
+const closeMenu = (restoreFocus = false) => {
+  shouldRestoreFocus.value = restoreFocus;
+  isMenuOpen.value = false;
+};
+
+const onEscape = (event: KeyboardEvent) => {
+  if (event.key !== "Escape" || !isMenuOpen.value) {
+    return;
+  }
+
+  event.preventDefault();
+  closeMenu(true);
+};
+
+const onResize = () => {
+  if (window.innerWidth >= 768 && isMenuOpen.value) {
+    closeMenu(false);
+  }
+};
+
+const onHashChange = () => {
+  if (isMenuOpen.value) {
+    closeMenu(false);
+  }
+};
+
+watch(isMenuOpen, async (open) => {
+  document.body.style.overflow = open ? "hidden" : "";
+
+  if (open) {
+    await nextTick();
+    const firstLink = mobileMenuRef.value?.querySelector<HTMLAnchorElement>("a");
+    firstLink?.focus();
+    return;
+  }
+
+  if (shouldRestoreFocus.value) {
+    menuButtonRef.value?.focus();
+  }
+});
+
+onMounted(() => {
+  window.addEventListener("keydown", onEscape);
+  window.addEventListener("resize", onResize);
+  window.addEventListener("hashchange", onHashChange);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener("keydown", onEscape);
+  window.removeEventListener("resize", onResize);
+  window.removeEventListener("hashchange", onHashChange);
+  document.body.style.overflow = "";
+});
 </script>
 
 <template>
-  <header
-    class="sticky top-0 z-20 mb-14 bg-[#ffffff]/95 dark:bg-[#111111]/95 backdrop-blur-sm border-b border-[#0077cc]/30 dark:border-[#0077cc]/50 header-animate"
-  >
-    <nav
-      class="mx-auto flex w-full items-center justify-between gap-3 py-4"
-      aria-label="Page sections"
+  <header class="sticky top-4 z-40">
+    <div
+      class="rounded-3xl border border-[var(--border)] bg-[rgba(255,253,252,0.9)] px-4 py-3 shadow-[0_8px_26px_rgba(75,57,41,0.07)] backdrop-blur-md sm:px-6"
     >
-      <div class="flex items-center gap-2">
-        <span
-          class="text-base font-bold font-['Orbitron'] tracking-wider text-[#0077cc] cyber-glow"
-        >
-          IVAN_ANGJELKOSKI
-        </span>
-      </div>
+      <nav class="flex items-center justify-between gap-4" aria-label="Primary navigation">
+        <a href="#home" class="group inline-flex min-w-0 items-center gap-2">
+          <span
+            class="hidden text-[0.62rem] font-semibold uppercase tracking-[0.3em] text-[var(--text-muted)] sm:inline"
+          >
+            Portfolio
+          </span>
+          <span
+            class="truncate font-['Cormorant_Garamond'] text-[1.15rem] font-semibold tracking-[0.03em] text-[var(--text)] sm:text-[1.25rem]"
+          >
+            Ivan Angjelkoski
+          </span>
+        </a>
 
-      <div class="flex items-center gap-2">
-        <button
-          @click="toggleTheme"
-          class="flex items-center justify-center w-10 h-10 rounded-none border border-[#0077cc] bg-[#ebebeb] dark:bg-[#1a1a1a] text-[#0077cc] transition hover:bg-[#0077cc] hover:text-[#ffffff] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]"
-          aria-label="Toggle theme"
-        >
-          <svg
-            v-if="colorMode.value === 'dark'"
-            class="w-5 h-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
-            />
-          </svg>
-          <svg
-            v-else
-            class="w-5 h-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
-            />
-          </svg>
-        </button>
+        <ul class="hidden items-center gap-6 md:flex" role="list">
+          <li v-for="link in navLinks" :key="link.href">
+            <a :href="link.href" class="nav-link">
+              {{ link.label }}
+            </a>
+          </li>
+        </ul>
 
         <button
-          class="md:hidden flex items-center justify-center w-10 h-10 rounded-none border border-[#0077cc] bg-[#ebebeb] dark:bg-[#1a1a1a] text-[#0077cc] transition hover:bg-[#0077cc] hover:text-[#ffffff] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]"
+          ref="menuButtonRef"
+          class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[var(--border)] bg-[var(--surface)] text-[var(--text)] md:hidden"
           :aria-expanded="isMenuOpen"
           aria-controls="mobile-menu"
-          aria-label="Toggle navigation menu"
-          @click="isMenuOpen = !isMenuOpen"
+          aria-label="Open navigation menu"
+          @click="openMenu"
         >
           <svg
-            v-if="!isMenuOpen"
-            class="w-5 h-5"
+            class="h-5 w-5"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -92,101 +123,87 @@ const navLinks = [
             <path
               stroke-linecap="round"
               stroke-linejoin="round"
-              stroke-width="2"
-              d="M4 6h16M4 12h16M4 18h16"
-            />
-          </svg>
-          <svg
-            v-else
-            class="w-5 h-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M6 18L18 6M6 6l12 12"
+              stroke-width="1.8"
+              d="M4 7h16M4 12h16M4 17h16"
             />
           </svg>
         </button>
-      </div>
-
-      <div class="hidden md:flex flex-wrap items-center gap-1">
-        <a
-          v-for="link in navLinks"
-          :key="link.href"
-          :href="link.href"
-          class="relative px-4 py-2 text-sm font-medium font-['Share_Tech_Mono'] text-[#1a1a1a] dark:text-[#e5e5e5] transition-all duration-200 hover:text-[#0077cc] hover:shadow-[0_0_10px_#0077cc] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]/50"
-        >
-          [{{ link.label }}]
-        </a>
-      </div>
-    </nav>
+      </nav>
+    </div>
 
     <Transition
-      enter-active-class="transition duration-200 ease-out"
-      enter-from-class="-translate-x-full"
-      enter-to-class="translate-x-0"
+      enter-active-class="transition duration-300 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
       leave-active-class="transition duration-200 ease-in"
-      leave-from-class="translate-x-0"
-      leave-to-class="-translate-x-full"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
     >
       <div
         v-if="isMenuOpen"
-        id="mobile-menu"
-        class="md:hidden fixed inset-y-0 left-0 z-50 w-64 bg-[#ffffff] dark:bg-[#111111] shadow-[0_0_30px_rgba(0,119,204,0.3)] border-r border-[#0077cc]/30"
+        class="fixed inset-0 z-50 md:hidden"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Mobile navigation"
       >
-        <div
-          class="flex h-16 items-center justify-between border-b border-[#0077cc]/30 px-4"
+        <button
+          class="absolute inset-0 h-full w-full bg-[rgba(47,42,38,0.28)] backdrop-blur-[1px]"
+          aria-label="Close navigation menu"
+          @click="closeMenu(true)"
+        />
+
+        <Transition
+          enter-active-class="transition duration-300 ease-out"
+          enter-from-class="translate-y-5 opacity-0"
+          enter-to-class="translate-y-0 opacity-100"
+          leave-active-class="transition duration-200 ease-in"
+          leave-from-class="translate-y-0 opacity-100"
+          leave-to-class="translate-y-4 opacity-0"
         >
-          <span
-            class="text-base font-bold font-['Orbitron'] tracking-wider text-[#0077cc]"
+          <aside
+            id="mobile-menu"
+            ref="mobileMenuRef"
+            class="absolute left-4 right-4 top-4 rounded-3xl border border-[var(--border)] bg-[var(--surface)] p-5 shadow-[0_26px_50px_rgba(73,54,38,0.2)]"
+            @click.stop
           >
-            IVAN_ANGJELKOSKI
-          </span>
-          <button
-            class="flex items-center justify-center w-8 h-8 rounded-none border border-[#0077cc]/50 text-[#0077cc] hover:bg-[#0077cc] hover:text-[#ffffff] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]"
-            aria-label="Close menu"
-            @click="isMenuOpen = false"
-          >
-            <svg
-              class="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-        <div class="p-4 space-y-2">
-          <a
-            v-for="link in navLinks"
-            :key="link.href"
-            :href="link.href"
-            class="block w-full px-4 py-3 text-sm font-medium font-['Share_Tech_Mono'] text-[#1a1a1a] dark:text-[#e5e5e5] rounded-none border border-transparent hover:border-[#0077cc] hover:text-[#0077cc] transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]/50"
-            @click="isMenuOpen = false"
-          >
-            [{{ link.label }}]
-          </a>
-        </div>
+            <div class="mb-4 flex items-center justify-between">
+              <p class="font-['Cormorant_Garamond'] text-2xl font-semibold text-[var(--text)]">Menu</p>
+              <button
+                class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-[var(--border)] text-[var(--text-muted)]"
+                aria-label="Close navigation menu"
+                @click="closeMenu(true)"
+              >
+                <svg
+                  class="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.8"
+                    d="M6 18 18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            <ul class="space-y-1" role="list">
+              <li v-for="link in navLinks" :key="`mobile-${link.href}`">
+                <a
+                  :href="link.href"
+                  class="block rounded-2xl px-4 py-3 text-sm font-semibold uppercase tracking-[0.13em] text-[var(--text-muted)] hover:bg-[var(--bg-soft)] hover:text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(191,165,138,0.38)]"
+                  @click="closeMenu(false)"
+                >
+                  {{ link.label }}
+                </a>
+              </li>
+            </ul>
+          </aside>
+        </Transition>
       </div>
     </Transition>
-
-    <div
-      v-if="isMenuOpen"
-      class="md:hidden fixed inset-0 bg-black/70 z-40"
-      aria-hidden="true"
-      @click="isMenuOpen = false"
-    />
   </header>
 </template>

--- a/app/components/ContactSection.vue
+++ b/app/components/ContactSection.vue
@@ -1,40 +1,37 @@
 <template>
-  <section id="contact" class="mt-16 rounded-none border border-[#0077cc]/30 bg-[#ffffff] dark:bg-[#111111] p-8 text-center relative contact-animate">
-    <div class="absolute top-0 left-0 w-3 h-3 border-t-2 border-l-2 border-[#0077cc]" />
-    <div class="absolute top-0 right-0 w-3 h-3 border-t-2 border-r-2 border-[#0077cc]" />
-    <div class="absolute bottom-0 left-0 w-3 h-3 border-b-2 border-l-2 border-[#0077cc]" />
-    <div class="absolute bottom-0 right-0 w-3 h-3 border-b-2 border-r-2 border-[#0077cc]" />
-    
-    <h2 class="text-2xl font-bold font-['Orbitron'] md:text-3xl text-[#1a1a1a] dark:text-[#e5e5e5]">
-      <span class="text-[#0077cc]">></span> Let<span class="text-[#0077cc]">'</span>s Build Something Together
-    </h2>
-    <p class="mx-auto mt-3 max-w-2xl text-[#555555] dark:text-[#999999] font-['Share_Tech_Mono']">
-      > Open to collaborating on ambitious frontend and Web3 products.<br/>
-      > Feel free to reach out for opportunities, consulting, or partnerships.
-    </p>
-    <div class="mt-6 flex flex-wrap items-center justify-center gap-3">
-      <a
-        href="mailto:ivan@example.com"
-        class="rounded-none border border-[#0077cc] bg-[#0077cc] px-5 py-2.5 text-sm font-semibold font-['Orbitron'] text-[#ffffff] transition hover:bg-[#0099e6] hover:shadow-[0_0_20px_#0077cc] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]"
-      >
-        EMAIL_ME
-      </a>
-      <a
-        href="https://github.com"
-        target="_blank"
-        rel="noreferrer"
-        class="rounded-none border border-[#0077cc]/50 bg-transparent px-5 py-2.5 text-sm font-semibold font-['Orbitron'] text-[#0077cc] transition hover:bg-[#0077cc]/10 hover:shadow-[0_0_10px_#0077cc] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]"
-      >
-        GITHUB
-      </a>
-      <a
-        href="https://linkedin.com"
-        target="_blank"
-        rel="noreferrer"
-        class="rounded-none border border-[#0077cc]/50 bg-transparent px-5 py-2.5 text-sm font-semibold font-['Orbitron'] text-[#0077cc] transition hover:bg-[#0077cc]/10 hover:shadow-[0_0_10px_#0077cc] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#0077cc]"
-      >
-        LINKEDIN
-      </a>
+  <section
+    id="contact"
+    class="section-shell contact-animate relative overflow-hidden p-7 text-center sm:p-10"
+  >
+    <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(216,195,165,0.3),transparent_55%)]" />
+
+    <div class="relative mx-auto max-w-3xl space-y-5">
+      <span class="editorial-label mx-auto justify-center">Contact</span>
+      <h2 class="section-heading">Open to thoughtful product collaborations and new opportunities.</h2>
+      <p class="section-intro mx-auto">
+        If you are hiring for frontend engineering, planning a product redesign, or exploring a
+        polished Web3 experience, I would be glad to connect and discuss how I can contribute.
+      </p>
+
+      <div class="flex flex-col justify-center gap-3 pt-2 sm:flex-row sm:flex-wrap">
+        <a href="mailto:ivan@example.com" class="btn btn-primary">Email</a>
+        <a
+          href="https://github.com"
+          target="_blank"
+          rel="noreferrer"
+          class="btn btn-secondary"
+        >
+          GitHub
+        </a>
+        <a
+          href="https://linkedin.com"
+          target="_blank"
+          rel="noreferrer"
+          class="btn btn-secondary"
+        >
+          LinkedIn
+        </a>
+      </div>
     </div>
   </section>
 </template>

--- a/app/components/ExperienceSection.vue
+++ b/app/components/ExperienceSection.vue
@@ -1,29 +1,86 @@
+<script setup lang="ts">
+type ExperienceEntry = {
+  company: string;
+  role: string;
+  timeline: string;
+  summary: string;
+  impacts: string[];
+  technologies: string[];
+};
+
+const experience: ExperienceEntry[] = [
+  {
+    company: "Injective Labs",
+    role: "Frontend Developer",
+    timeline: "2022 — Present · 3 years",
+    summary:
+      "Leading frontend delivery for trading and DeFi product surfaces where usability and execution confidence are critical.",
+    impacts: [
+      "Built high-fidelity interfaces for market workflows, account operations, and transaction-heavy states.",
+      "Partnered across product, design, and blockchain teams to simplify complex transaction journeys.",
+      "Improved maintainability with reusable component patterns, typed contracts, and performance-first implementation.",
+    ],
+    technologies: ["Nuxt", "Vue", "TypeScript", "Web3", "Cosmos ecosystem"],
+  },
+];
+</script>
+
 <template>
-  <section id="experience" class="mt-16 space-y-6 experience-animate">
-    <h2 class="text-2xl font-bold font-['Orbitron'] md:text-3xl text-[#1a1a1a] dark:text-[#e5e5e5]">
-      <span class="text-[#0077cc]">></span> Experience
-    </h2>
-    <article class="rounded-none border border-[#0077cc]/30 bg-[#ffffff] dark:bg-[#111111] p-7 transition duration-300 hover:border-[#0077cc] hover:shadow-[0_0_20px_rgba(0,119,204,0.2)]">
-      <div class="flex flex-wrap items-baseline justify-between gap-3">
-        <h3 class="text-xl font-semibold font-['Orbitron'] text-[#1a1a1a] dark:text-[#e5e5e5]">
-          <span class="text-[#0077cc]">@</span> Injective Labs — Frontend Developer
-        </h3>
-        <p class="text-sm font-['Share_Tech_Mono'] text-[#555555] dark:text-[#999999]">2022 — Present | 3 years</p>
-      </div>
-      <ul class="mt-5 list-none space-y-2 pl-5 text-[#555555] dark:text-[#999999] font-['Share_Tech_Mono']">
-        <li class="relative">
-          <span class="absolute -left-5 text-[#0077cc]">></span>
-          Delivering production-grade UI for fast-moving trading and DeFi-focused workflows.
-        </li>
-        <li class="relative">
-          <span class="absolute -left-5 text-[#0077cc]">></span>
-          Collaborating with product, design, and blockchain teams to ship clear and reliable transaction experiences.
-        </li>
-        <li class="relative">
-          <span class="absolute -left-5 text-[#0077cc]">></span>
-          Improving frontend performance and maintainability using reusable architecture and typed development practices.
-        </li>
-      </ul>
-    </article>
+  <section id="experience" class="experience-animate space-y-8">
+    <div class="space-y-4">
+      <span class="editorial-label">Experience</span>
+      <h2 class="section-heading">Product impact shaped through thoughtful frontend execution.</h2>
+    </div>
+
+    <div class="space-y-6">
+      <article
+        v-for="item in experience"
+        :key="`${item.company}-${item.role}`"
+        class="premium-card experience-animate relative overflow-hidden p-6 sm:p-8"
+      >
+        <div class="absolute left-0 top-0 h-full w-1 bg-[color:color-mix(in_srgb,var(--accent-strong)_55%,transparent)]" />
+
+        <div class="ml-2 space-y-6 sm:ml-4">
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p class="muted-meta">{{ item.company }}</p>
+              <h3 class="mt-1 font-['Cormorant_Garamond'] text-3xl font-semibold text-[var(--text)]">
+                {{ item.role }}
+              </h3>
+            </div>
+            <p class="rounded-full border border-[var(--border)] bg-[var(--bg-soft)] px-3 py-1 text-xs font-semibold uppercase tracking-[0.12em] text-[var(--text-muted)]">
+              {{ item.timeline }}
+            </p>
+          </div>
+
+          <p class="text-[0.98rem] leading-8 text-[var(--text-muted)]">
+            {{ item.summary }}
+          </p>
+
+          <ul class="space-y-3 text-[0.95rem] leading-7 text-[var(--text-muted)]">
+            <li
+              v-for="impact in item.impacts"
+              :key="impact"
+              class="relative pl-5"
+            >
+              <span class="absolute left-0 top-[0.75rem] h-1.5 w-1.5 rounded-full bg-[var(--accent-strong)]" />
+              {{ impact }}
+            </li>
+          </ul>
+
+          <div class="soft-divider" />
+
+          <div class="flex flex-wrap gap-2">
+            <span
+              v-for="technology in item.technologies"
+              :key="technology"
+              class="chip"
+            >
+              {{ technology }}
+            </span>
+          </div>
+        </div>
+      </article>
+    </div>
   </section>
 </template>

--- a/app/components/ProjectsSection.vue
+++ b/app/components/ProjectsSection.vue
@@ -1,49 +1,135 @@
 <script setup lang="ts">
-const highlights = [
+type ProjectLink = {
+  label: "Live" | "Code" | "Case Study";
+  href: string | null;
+};
+
+type Project = {
+  name: string;
+  description: string;
+  role: string;
+  stack: string[];
+  featured?: boolean;
+  links: ProjectLink[];
+};
+
+const projects: Project[] = [
   {
     name: "Injective Trading Dashboard",
+    role: "Frontend architecture and interaction design",
     description:
-      "Built a responsive analytics dashboard with real-time market data visualizations and wallet-aware UX patterns for high-frequency crypto users.",
+      "Crafted a responsive analytics dashboard with real-time market surfaces and wallet-aware interactions designed for fast, high-context decision making.",
     stack: ["Nuxt", "TypeScript", "Tailwind", "WebSockets"],
+    featured: true,
+    links: [
+      { label: "Live", href: null },
+      { label: "Code", href: null },
+      { label: "Case Study", href: null },
+    ],
   },
   {
     name: "Cross-Chain dApp Experience",
+    role: "Transaction flow UX and implementation",
     description:
-      "Implemented a multi-step transaction flow focused on clarity, error recovery, and execution confidence for Cosmos-based users.",
-    stack: ["Vue", "Web3", "Cosmos", "Composable Architecture"],
+      "Designed and implemented a multi-step cross-chain transaction journey focused on clarity, confidence states, and graceful error recovery.",
+    stack: ["Vue", "Cosmos", "Web3", "Composable architecture"],
+    links: [
+      { label: "Live", href: null },
+      { label: "Code", href: null },
+      { label: "Case Study", href: null },
+    ],
   },
   {
     name: "Frontend Platform & UI System",
+    role: "System design and shared component strategy",
     description:
-      "Created reusable design primitives and shared component guidelines that improved consistency and reduced delivery time across product squads.",
-    stack: ["React", "Next.js", "Storybook", "Design Tokens"],
+      "Established reusable UI primitives, documentation patterns, and tokenized design foundations that improved consistency and delivery speed across teams.",
+    stack: ["React", "Next.js", "Storybook", "Design tokens"],
+    links: [
+      { label: "Live", href: null },
+      { label: "Code", href: null },
+      { label: "Case Study", href: null },
+    ],
   },
 ];
 </script>
 
 <template>
-  <section id="projects" class="mt-16 space-y-6 projects-animate">
-    <h2 class="text-2xl font-bold font-['Orbitron'] md:text-3xl text-[#1a1a1a] dark:text-[#e5e5e5]">
-      <span class="text-[#0077cc]">></span> Selected Projects
-    </h2>
-    <div class="grid gap-5 md:grid-cols-3">
+  <section id="projects" class="projects-animate space-y-8">
+    <div class="space-y-4">
+      <span class="editorial-label">Featured Work</span>
+      <h2 class="section-heading">Selected projects presented as crafted case-study moments.</h2>
+      <p class="section-intro">
+        Each project balances functional clarity with visual polish, translating complex product
+        requirements into interfaces that feel natural, reliable, and intentionally designed.
+      </p>
+    </div>
+
+    <div class="grid gap-5 lg:grid-cols-3">
       <article
-        v-for="project in highlights"
+        v-for="(project, index) in projects"
         :key="project.name"
-        class="rounded-none border border-[#0077cc]/30 bg-[#ffffff] dark:bg-[#111111] p-6 transition duration-300 hover:border-[#0077cc] hover:shadow-[0_0_20px_rgba(0,119,204,0.2)] group"
+        class="project-shell projects-animate p-5"
       >
-        <h3 class="text-lg font-semibold font-['Orbitron'] text-[#1a1a1a] dark:text-[#e5e5e5] group-hover:text-[#0077cc] transition">
-          {{ project.name }}
-        </h3>
-        <p class="mt-3 text-sm leading-relaxed text-[#555555] dark:text-[#999999] font-['Share_Tech_Mono']">{{ project.description }}</p>
-        <div class="mt-4 flex flex-wrap gap-2">
-          <span
-            v-for="tech in project.stack"
-            :key="tech"
-            class="rounded-none border border-[#cccccc] dark:border-[#333333] bg-[#f5f5f5] dark:bg-[#1a1a1a] px-3 py-1 text-xs font-['Share_Tech_Mono'] text-[#555555] dark:text-[#999999] group-hover:border-[#0077cc]/50 group-hover:text-[#0077cc] transition"
-          >
-            {{ tech }}
-          </span>
+        <div class="media-frame h-44 p-4">
+          <div class="flex h-full flex-col justify-between rounded-[0.75rem] border border-[rgba(140,111,90,0.2)] bg-[rgba(255,253,252,0.48)] p-4">
+            <p class="muted-meta">Case {{ String(index + 1).padStart(2, '0') }}</p>
+            <p class="font-['Cormorant_Garamond'] text-2xl leading-tight text-[var(--text)]">{{ project.name }}</p>
+          </div>
+        </div>
+
+        <div class="mt-5 space-y-4">
+          <div class="flex items-center justify-between gap-3">
+            <h3 class="font-['Cormorant_Garamond'] text-[1.85rem] font-semibold leading-none text-[var(--text)]">
+              {{ project.name }}
+            </h3>
+            <span
+              v-if="project.featured"
+              class="rounded-full border border-[color:color-mix(in_srgb,var(--accent-strong)_45%,transparent)] bg-[color:color-mix(in_srgb,var(--accent)_42%,white)] px-3 py-1 text-[0.62rem] font-semibold uppercase tracking-[0.16em] text-[var(--text-muted)]"
+            >
+              Featured
+            </span>
+          </div>
+
+          <p class="text-sm uppercase tracking-[0.13em] text-[var(--text-muted)]">{{ project.role }}</p>
+
+          <p class="text-[0.95rem] leading-7 text-[var(--text-muted)]">
+            {{ project.description }}
+          </p>
+
+          <div class="flex flex-wrap gap-2">
+            <span
+              v-for="tech in project.stack"
+              :key="tech"
+              class="chip"
+            >
+              {{ tech }}
+            </span>
+          </div>
+
+          <div class="soft-divider" />
+
+          <div class="flex flex-wrap gap-2">
+            <template v-for="link in project.links" :key="`${project.name}-${link.label}`">
+              <a
+                v-if="link.href"
+                :href="link.href"
+                target="_blank"
+                rel="noreferrer"
+                class="link-chip"
+              >
+                {{ link.label }}
+              </a>
+              <span
+                v-else
+                class="link-chip"
+                aria-disabled="true"
+                role="status"
+              >
+                {{ link.label }} · On request
+              </span>
+            </template>
+          </div>
         </div>
       </article>
     </div>

--- a/app/components/SkillsSection.vue
+++ b/app/components/SkillsSection.vue
@@ -1,34 +1,67 @@
 <script setup lang="ts">
-const skills = [
-  "Vue",
-  "Nuxt",
-  "React",
-  "Next.js",
-  "TypeScript",
-  "Web3",
-  "Cosmos",
-  "Node/Bun",
-  "Hono",
+type SkillGroup = {
+  category: string;
+  items: string[];
+};
+
+const skillGroups: SkillGroup[] = [
+  {
+    category: "Frontend",
+    items: ["Vue", "Nuxt", "React", "Next.js", "TypeScript"],
+  },
+  {
+    category: "Backend",
+    items: ["Node.js", "Bun", "Hono", "REST APIs"],
+  },
+  {
+    category: "Design / UI",
+    items: ["Design systems", "Component architecture", "Interaction polish"],
+  },
+  {
+    category: "Tooling",
+    items: ["Tailwind CSS", "Storybook", "ESLint", "GitHub Actions"],
+  },
+  {
+    category: "Performance / Accessibility",
+    items: ["Core Web Vitals", "A11y-first markup", "Progressive enhancement"],
+  },
+  {
+    category: "Deployment",
+    items: ["Static deployment", "CI/CD pipelines", "Environment strategy"],
+  },
 ];
 </script>
 
 <template>
-  <section id="skills" class="mt-16 space-y-6 skills-animate">
-    <h2 class="text-2xl font-bold font-['Orbitron'] md:text-3xl text-[#1a1a1a] dark:text-[#e5e5e5]">
-      <span class="text-[#0077cc]">></span> Skills <span class="text-[#0077cc]">&</span> Technologies
-    </h2>
-    <p class="max-w-3xl text-[#555555] dark:text-[#999999] font-['Share_Tech_Mono']">
-      > A practical frontend toolkit for building robust web apps, full-stack services, and
-      blockchain-integrated products.
-    </p>
-    <div class="flex flex-wrap gap-3">
-      <span
-        v-for="skill in skills"
-        :key="skill"
-        class="rounded-none border border-[#0077cc]/50 bg-[#f5f5f5] dark:bg-[#1a1a1a] px-4 py-2 text-sm font-['Share_Tech_Mono'] text-[#1a1a1a] dark:text-[#e5e5e5] hover:border-[#0077cc] hover:text-[#0077cc] hover:shadow-[0_0_10px_#0077cc] transition"
+  <section id="skills" class="skills-animate space-y-8">
+    <div class="space-y-4">
+      <span class="editorial-label">Capabilities</span>
+      <h2 class="section-heading">A curated toolkit for building polished digital products.</h2>
+      <p class="section-intro">
+        My work spans interface architecture, implementation quality, and maintainable delivery.
+        I combine engineering rigor with design sensitivity to produce reliable product experiences.
+      </p>
+    </div>
+
+    <div class="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+      <article
+        v-for="group in skillGroups"
+        :key="group.category"
+        class="premium-card skills-animate p-5"
       >
-        [{{ skill }}]
-      </span>
+        <h3 class="font-['Cormorant_Garamond'] text-2xl font-semibold text-[var(--text)]">
+          {{ group.category }}
+        </h3>
+        <div class="mt-4 flex flex-wrap gap-2">
+          <span
+            v-for="item in group.items"
+            :key="item"
+            class="chip"
+          >
+            {{ item }}
+          </span>
+        </div>
+      </article>
     </div>
   </section>
 </template>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -6,107 +6,87 @@ import { onMounted } from "vue";
 gsap.registerPlugin(ScrollTrigger);
 
 onMounted(() => {
-  gsap.from(".header-animate", {
-    y: -50,
-    opacity: 0,
-    duration: 0.8,
-    ease: "power3.out",
-    stagger: 0.1,
-  });
-
-  gsap.from(".about-animate", {
-    scrollTrigger: {
-      trigger: "#about",
-      start: "top 80%",
-    },
-    y: 60,
-    opacity: 0,
-    duration: 1,
-    ease: "power3.out",
-    stagger: 0.15,
-  });
-
   gsap.from(".skills-animate", {
     scrollTrigger: {
       trigger: "#skills",
-      start: "top 80%",
+      start: "top 84%",
+      once: true,
     },
-    y: 40,
+    y: 24,
     opacity: 0,
     duration: 0.8,
-    ease: "power3.out",
-    stagger: 0.1,
+    ease: "power2.out",
+    stagger: 0.12,
   });
 
   gsap.from(".experience-animate", {
     scrollTrigger: {
       trigger: "#experience",
-      start: "top 80%",
+      start: "top 84%",
+      once: true,
     },
-    y: 40,
+    y: 24,
     opacity: 0,
     duration: 0.8,
-    ease: "power3.out",
-    stagger: 0.15,
+    ease: "power2.out",
+    stagger: 0.12,
   });
 
   gsap.from(".projects-animate", {
     scrollTrigger: {
       trigger: "#projects",
-      start: "top 80%",
+      start: "top 84%",
+      once: true,
     },
-    y: 40,
+    y: 24,
     opacity: 0,
     duration: 0.8,
-    ease: "power3.out",
-    stagger: 0.15,
+    ease: "power2.out",
+    stagger: 0.1,
   });
 
   gsap.from(".contact-animate", {
     scrollTrigger: {
       trigger: "#contact",
-      start: "top 80%",
+      start: "top 86%",
+      once: true,
     },
-    y: 40,
+    y: 24,
     opacity: 0,
-    duration: 0.8,
-    ease: "power3.out",
-    stagger: 0.1,
+    duration: 0.75,
+    ease: "power2.out",
   });
 
   gsap.from(".footer-animate", {
     scrollTrigger: {
       trigger: "footer",
-      start: "top 90%",
+      start: "top 92%",
+      once: true,
     },
-    y: 20,
+    y: 16,
     opacity: 0,
-    duration: 0.6,
-    ease: "power3.out",
+    duration: 0.7,
+    ease: "power2.out",
   });
 });
 
 useSeoMeta({
   title: "Ivan Angjelkoski — Frontend Developer",
   description:
-    "Frontend Developer at Injective Labs with 3 years of experience building performant web and Web3 products with Vue, Nuxt, React, and TypeScript from North Macedonia.",
+    "Frontend Developer at Injective Labs crafting polished, high-performance web and Web3 interfaces with Vue, Nuxt, React, and TypeScript.",
   ogTitle: "Ivan Angjelkoski — Frontend Developer",
   ogDescription:
-    "Frontend Developer at Injective Labs building modern interfaces for Web2 and Web3 products.",
+    "A premium editorial portfolio presenting frontend craftsmanship across modern web and Web3 products.",
   twitterCard: "summary_large_image",
 });
 </script>
 
 <template>
-  <div class="relative overflow-hidden bg-[#f5f5f5] dark:bg-[#050505] text-[#1a1a1a] dark:text-[#e5e5e5]">
-    <div class="pointer-events-none absolute inset-0 tech-grid opacity-50" />
+  <div id="home" class="relative min-h-screen overflow-x-clip text-[var(--text)]">
+    <div class="page-shell mx-auto w-full max-w-[1120px] px-5 pb-20 pt-6 sm:px-8 lg:px-10">
+      <AppHeader />
 
-    <div
-      class="relative mx-auto min-h-screen w-full max-w-6xl px-6 pb-24 pt-8 md:px-10 scan-line"
-    >
-      <AppHeader v-bind="{ bar: 1 }" />
-
-      <main>
+      <main class="mt-8 space-y-20 pb-12 sm:space-y-24">
         <AboutSection />
         <SkillsSection />
         <ExperienceSection />

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -7,17 +7,10 @@ export default defineNuxtConfig({
   css: ["~/assets/css/main.css"],
   app: {
     head: {
-      link: [
-        { rel: "icon", type: "image/svg+xml", href: "/favicon.svg" }
-      ]
-    }
+      link: [{ rel: "icon", type: "image/svg+xml", href: "/favicon.svg" }],
+    },
   },
-  modules: ["@nuxt/eslint", "@nuxtjs/color-mode"],
-  colorMode: {
-    fallback: "dark",
-    storageKey: "ivan-angjelkoski-color-mode",
-    preference: "dark",
-  },
+  modules: ["@nuxt/eslint"],
   vite: {
     plugins: [tailwindcss()],
   },


### PR DESCRIPTION
This PR fully redesigns the portfolio from the previous cyber style to a soft editorial visual system with reusable design tokens, updated typography, and rewritten section layouts/copy. It removes dark-mode support and consolidates the app into a cohesive light theme across header, hero/about, skills, experience, projects, contact, and footer. It also refactors the navbar for best-practice mobile/desktop behavior with semantic lists, accessible dialog-style mobile navigation, focus management, escape/overlay close handling, resize/hash close behavior, and body scroll locking. Build validation was run with pnpm build.