### PR TITLE
fix: switch nav to mobile menu at tablet widths (md → lg)

### DIFF
--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -41,7 +41,7 @@ const onEscape = (event: KeyboardEvent) => {
 };
 
 const onResize = () => {
-  if (window.innerWidth >= 768 && isMenuOpen.value) {
+  if (window.innerWidth >= 1024 && isMenuOpen.value) {
     closeMenu(false);
   }
 };
@@ -128,7 +128,7 @@ onBeforeUnmount(() => {
           </span>
         </a>
 
-        <ul class="hidden items-center gap-5 md:flex" role="list">
+        <ul class="hidden items-center gap-5 lg:flex" role="list">
           <li v-for="link in navLinks" :key="link.href">
             <a
               :href="link.href"
@@ -144,7 +144,7 @@ onBeforeUnmount(() => {
 
         <button
           ref="menuButtonRef"
-          class="inline-flex h-10 w-10 items-center justify-center border border-[var(--color-border-strong)] bg-[var(--color-bg-inset)] text-[var(--color-accent)] md:hidden"
+          class="inline-flex h-10 w-10 items-center justify-center border border-[var(--color-border-strong)] bg-[var(--color-bg-inset)] text-[var(--color-accent)] lg:hidden"
           :aria-expanded="isMenuOpen"
           aria-controls="mobile-menu"
           aria-label="Open navigation menu"
@@ -178,7 +178,7 @@ onBeforeUnmount(() => {
     >
       <div
         v-if="isMenuOpen"
-        class="fixed inset-0 z-50 md:hidden"
+        class="fixed inset-0 z-50 lg:hidden"
         role="dialog"
         aria-modal="true"
         aria-label="Mobile navigation"


### PR DESCRIPTION
## Summary

At tablet sizes (768–1023px) the full 6-link desktop navbar was rendering, but it was too cramped for the available width, causing header/navbar items to overlap.

This moves the header's mobile breakpoint so the hamburger menu triggers earlier.

## Changes

The desktop nav / mobile-menu switch happened at Tailwind's `md` (768px). Bumped it to `lg` (1024px):

| Element | Before | After |
|---|---|---|
| Desktop nav `<ul>` | `md:flex` | `lg:flex` |
| Hamburger button | `md:hidden` | `lg:hidden` |
| Mobile menu overlay | `md:hidden` | `lg:hidden` |
| `onResize` auto-close threshold (JS) | `768` | `1024` |

All changes are isolated to `app/components/AppHeader.vue`. The `md:` breakpoint was used **only** in this component, so nothing else in the app is affected.

## Result

- **< 1024px** (phones, small tablets, iPad portrait): hamburger menu ✅
- **≥ 1024px** (iPad landscape, desktops): full inline navbar ✅

## Test plan

- [ ] Open the site and resize the browser across 700px → 1100px
- [ ] Confirm no header overlap in the 768–1023px range
- [ ] Verify the hamburger toggles the mobile menu correctly
- [ ] Verify the menu auto-closes when crossing the 1024px threshold
- [ ] Confirm full navbar still renders cleanly at ≥ 1024px
