### PR TITLE
feat: convert site to light mode

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -3,38 +3,38 @@
 
 :root {
   /* Backgrounds */
-  --color-bg: #050505;
-  --color-bg-elevated: #0b0b0c;
-  --color-bg-panel: #111113;
-  --color-bg-inset: #070708;
+  --color-bg: #f5f5f2;
+  --color-bg-elevated: #ffffff;
+  --color-bg-panel: #ffffff;
+  --color-bg-inset: #ebebe6;
 
   /* Borders */
-  --color-border: #2a2a2d;
-  --color-border-strong: #4a4a4f;
-  --color-border-accent: #f5ff00;
+  --color-border: #e1e1dc;
+  --color-border-strong: #c4c4be;
+  --color-border-accent: var(--color-accent);
 
   /* Text */
-  --color-text: #f2f2f2;
-  --color-text-muted: #a0a0a8;
-  --color-text-subtle: #66666f;
-  --color-text-inverse: #050505;
+  --color-text: #14141a;
+  --color-text-muted: #56565f;
+  --color-text-subtle: #86868e;
+  --color-text-inverse: #ffffff;
 
   /* Accent */
-  --color-accent: #f5ff00;
-  --color-accent-hover: #fbff4d;
-  --color-accent-active: #cdd600;
+  --color-accent: #7a6200;
+  --color-accent-hover: #947a00;
+  --color-accent-active: #635100;
 
   /* Secondary neon accents */
-  --color-cyan: #00eaff;
-  --color-magenta: #ff2bd6;
-  --color-red: #ff3b3b;
-  --color-green: #39ff88;
+  --color-cyan: #0098b5;
+  --color-magenta: #c81fa3;
+  --color-red: #d61f1f;
+  --color-green: #1f9e54;
 
   /* Status */
-  --color-success: #39ff88;
-  --color-warning: #f5ff00;
-  --color-error: #ff3b3b;
-  --color-info: #00eaff;
+  --color-success: #1f9e54;
+  --color-warning: #7a6200;
+  --color-error: #d61f1f;
+  --color-info: #0098b5;
 
   /* Motion */
   --ease-mech: cubic-bezier(0.16, 1, 0.3, 1);
@@ -42,9 +42,9 @@
   --dur-mid: 200ms;
 
   /* Shadows / glow */
-  --shadow-glow-yellow: 0 0 24px rgba(245, 255, 0, 0.3);
-  --shadow-glow-cyan: 0 0 24px rgba(0, 234, 255, 0.25);
-  --shadow-hard: 8px 8px 0 #000;
+  --shadow-glow-yellow: 0 0 24px rgba(122, 98, 0, 0.18);
+  --shadow-glow-cyan: 0 0 24px rgba(0, 152, 181, 0.16);
+  --shadow-hard: 8px 8px 0 rgba(20, 20, 26, 0.88);
 
   /* Backwards-compat aliases used by legacy markup */
   --bg: var(--color-bg);
@@ -74,9 +74,9 @@ body {
   color: var(--color-text);
   background-color: var(--color-bg);
   background-image:
-    radial-gradient(circle at 70% 18%, rgba(245, 255, 0, 0.10), transparent 32%),
-    radial-gradient(circle at 18% 82%, rgba(0, 234, 255, 0.06), transparent 30%),
-    linear-gradient(180deg, #060606 0%, #050505 60%);
+    radial-gradient(circle at 70% 18%, rgba(122, 98, 0, 0.05), transparent 32%),
+    radial-gradient(circle at 18% 82%, rgba(0, 152, 181, 0.04), transparent 30%),
+    linear-gradient(180deg, #fafaf7 0%, #f5f5f2 60%);
   background-attachment: fixed;
 }
 
@@ -87,8 +87,8 @@ body::before {
   inset: 0;
   pointer-events: none;
   background-image:
-    linear-gradient(rgba(74, 74, 79, 0.10) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(74, 74, 79, 0.10) 1px, transparent 1px);
+    linear-gradient(rgba(20, 20, 26, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(20, 20, 26, 0.05) 1px, transparent 1px);
   background-size: 48px 48px;
   -webkit-mask-image: radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
   mask-image: radial-gradient(circle at 50% 30%, #000 0%, transparent 78%);
@@ -104,13 +104,13 @@ body::after {
   background-image:
     repeating-linear-gradient(
       0deg,
-      rgba(0, 0, 0, 0.18) 0px,
-      rgba(0, 0, 0, 0.18) 1px,
+      rgba(20, 20, 26, 0.04) 0px,
+      rgba(20, 20, 26, 0.04) 1px,
       transparent 1px,
       transparent 3px
     );
   mix-blend-mode: multiply;
-  opacity: 0.5;
+  opacity: 0.35;
   z-index: 0;
 }
 
@@ -175,8 +175,8 @@ button {
   position: absolute;
   inset: 0;
   background:
-    radial-gradient(circle at 70% 30%, rgba(245, 255, 0, 0.16), transparent 28%),
-    radial-gradient(circle at 20% 80%, rgba(0, 234, 255, 0.08), transparent 26%);
+    radial-gradient(circle at 70% 30%, rgba(122, 98, 0, 0.07), transparent 28%),
+    radial-gradient(circle at 20% 80%, rgba(0, 152, 181, 0.05), transparent 26%);
   pointer-events: none;
 }
 
@@ -284,7 +284,7 @@ button {
   border: 1px solid var(--color-border);
   border-radius: 2px;
   background:
-    linear-gradient(180deg, rgba(245, 255, 0, 0.012), transparent 40%),
+    linear-gradient(180deg, rgba(122, 98, 0, 0.02), transparent 40%),
     var(--color-bg-panel);
   position: relative;
 }
@@ -399,7 +399,7 @@ button {
   background: var(--color-accent-hover);
   border-color: var(--color-accent-hover);
   transform: translate(2px, -2px);
-  box-shadow: 6px 6px 0 #000, 0 0 28px rgba(245, 255, 0, 0.45);
+  box-shadow: 6px 6px 0 rgba(20, 20, 26, 0.88), 0 0 28px rgba(122, 98, 0, 0.3);
 }
 
 .btn-primary:active {
@@ -417,7 +417,7 @@ button {
 .btn-secondary:hover {
   border-color: var(--color-accent);
   color: var(--color-accent);
-  background: rgba(245, 255, 0, 0.05);
+  background: rgba(122, 98, 0, 0.08);
 }
 
 .btn:active {
@@ -515,7 +515,7 @@ button {
 .chip:hover {
   color: var(--color-accent);
   border-color: var(--color-accent);
-  background: rgba(245, 255, 0, 0.05);
+  background: rgba(122, 98, 0, 0.08);
 }
 
 /* ============ PROJECT SHELL ============ */
@@ -534,7 +534,7 @@ button {
 .project-shell:hover {
   transform: translate(-3px, -3px);
   border-color: var(--color-accent);
-  box-shadow: 6px 6px 0 #000, 0 0 24px rgba(245, 255, 0, 0.18);
+  box-shadow: 6px 6px 0 rgba(20, 20, 26, 0.88), 0 0 24px rgba(122, 98, 0, 0.16);
 }
 
 .media-frame {
@@ -543,16 +543,16 @@ button {
   border-radius: 2px;
   border: 1px solid var(--color-border-strong);
   background:
-    radial-gradient(circle at 80% 20%, rgba(245, 255, 0, 0.10), transparent 50%),
-    radial-gradient(circle at 10% 90%, rgba(0, 234, 255, 0.08), transparent 55%),
-    linear-gradient(135deg, #0c0c0e, #070708);
+    radial-gradient(circle at 80% 20%, rgba(122, 98, 0, 0.08), transparent 50%),
+    radial-gradient(circle at 10% 90%, rgba(0, 152, 181, 0.06), transparent 55%),
+    linear-gradient(135deg, #eeeee9, #e4e4df);
 }
 
 .media-frame::after {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, transparent 0%, rgba(245, 255, 0, 0.08) 35%, transparent 65%);
+  background: linear-gradient(120deg, transparent 0%, rgba(122, 98, 0, 0.12) 35%, transparent 65%);
   transform: translateX(-130%);
   transition: transform 650ms var(--ease-mech);
   pointer-events: none;
@@ -581,7 +581,7 @@ button {
 .link-chip:hover {
   color: var(--color-accent);
   border-color: var(--color-accent);
-  background: rgba(245, 255, 0, 0.05);
+  background: rgba(122, 98, 0, 0.08);
 }
 
 .link-chip[aria-disabled="true"] {

--- a/app/components/AppHeader.vue
+++ b/app/components/AppHeader.vue
@@ -105,14 +105,14 @@ onBeforeUnmount(() => {
 <template>
   <header class="sticky top-4 z-40">
     <div
-      class="border border-[var(--color-border)] bg-[rgba(11,11,12,0.78)] px-4 py-3 backdrop-blur-md sm:px-6"
+      class="border border-[var(--color-border)] bg-[rgba(255,255,255,0.82)] px-4 py-3 backdrop-blur-md sm:px-6"
       style="clip-path: polygon(0 0, 100% 0, 100% calc(100% - 12px), calc(100% - 12px) 100%, 0 100%);"
     >
       <nav class="flex items-center justify-between gap-4" aria-label="Primary navigation">
         <a href="#home" class="group inline-flex min-w-0 items-center gap-3">
           <span
             class="inline-flex h-7 w-7 items-center justify-center border border-[var(--color-accent)] font-['JetBrains_Mono'] text-[0.7rem] font-bold text-[var(--color-accent)]"
-            style="box-shadow: 0 0 12px rgba(245,255,0,0.4);"
+            style="box-shadow: 0 0 12px rgba(122,98,0,0.3);"
           >
             IA
           </span>
@@ -184,7 +184,7 @@ onBeforeUnmount(() => {
         aria-label="Mobile navigation"
       >
         <button
-          class="absolute inset-0 h-full w-full bg-[rgba(0,0,0,0.78)] backdrop-blur-[2px]"
+          class="absolute inset-0 h-full w-full bg-[rgba(20,20,26,0.5)] backdrop-blur-[2px]"
           aria-label="Close navigation menu"
           @click="closeMenu(true)"
         />
@@ -232,7 +232,7 @@ onBeforeUnmount(() => {
               <li v-for="link in navLinks" :key="`mobile-${link.href}`">
                 <a
                   :href="link.href"
-                  class="group flex items-center gap-3 border border-transparent px-4 py-3 font-['JetBrains_Mono'] text-sm font-medium uppercase tracking-[0.14em] text-[var(--color-text-muted)] hover:border-[var(--color-accent)] hover:bg-[rgba(245,255,0,0.05)] hover:text-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+                  class="group flex items-center gap-3 border border-transparent px-4 py-3 font-['JetBrains_Mono'] text-sm font-medium uppercase tracking-[0.14em] text-[var(--color-text-muted)] hover:border-[var(--color-accent)] hover:bg-[rgba(122,98,0,0.08)] hover:text-[var(--color-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
                   @click="closeMenu(false)"
                 >
                   <span class="text-[var(--color-text-subtle)]">{{ link.index }}</span>

--- a/app/components/ContactSection.vue
+++ b/app/components/ContactSection.vue
@@ -4,8 +4,8 @@
     class="contact-animate relative overflow-hidden border border-[var(--color-accent)] bg-[var(--color-bg-panel)] p-7 text-center sm:p-12"
     style="clip-path: polygon(0 16px, 16px 0, 100% 0, 100% calc(100% - 16px), calc(100% - 16px) 100%, 0 100%);"
   >
-    <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(245,255,0,0.16),transparent_62%)]" />
-    <div class="pointer-events-none absolute inset-0 opacity-[0.05] mix-blend-screen" style="background-image: linear-gradient(rgba(245,255,0,1) 1px, transparent 1px), linear-gradient(90deg, rgba(245,255,0,1) 1px, transparent 1px); background-size: 40px 40px;" />
+    <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(122,98,0,0.08),transparent_62%)]" />
+    <div class="pointer-events-none absolute inset-0 opacity-[0.5] mix-blend-multiply" style="background-image: linear-gradient(rgba(20,20,26,0.06) 1px, transparent 1px), linear-gradient(90deg, rgba(20,20,26,0.06) 1px, transparent 1px); background-size: 40px 40px;" />
 
     <div class="relative mx-auto max-w-3xl space-y-5">
       <p class="eyebrow mx-auto justify-center">// Initialize_Contact</p>

--- a/app/components/ExperienceSection.vue
+++ b/app/components/ExperienceSection.vue
@@ -38,7 +38,7 @@ const experience: ExperienceEntry[] = [
         :key="`${item.company}-${item.role}`"
         class="premium-card experience-animate relative overflow-hidden p-6 sm:p-8"
       >
-        <div class="absolute left-0 top-0 h-full w-1 bg-[var(--color-accent)]" style="box-shadow: 0 0 16px rgba(245,255,0,0.6);" />
+        <div class="absolute left-0 top-0 h-full w-1 bg-[var(--color-accent)]" style="box-shadow: 0 0 16px rgba(122,98,0,0.35);" />
 
         <div class="ml-3 space-y-6 sm:ml-5">
           <div class="flex flex-wrap items-start justify-between gap-3">

--- a/app/components/ProjectsSection.vue
+++ b/app/components/ProjectsSection.vue
@@ -74,7 +74,7 @@ const projects: Project[] = [
       >
         <div class="project-media lg:col-span-7">
           <div class="media-frame h-56 p-5 sm:h-72">
-            <div class="flex h-full flex-col justify-between border border-[var(--color-border-strong)] bg-[rgba(0,0,0,0.45)] p-5">
+            <div class="flex h-full flex-col justify-between border border-[var(--color-border-strong)] bg-[rgba(235,235,230,0.7)] p-5">
               <div class="flex items-center justify-between">
                 <p class="muted-meta tabular">CASE // {{ String(index + 1).padStart(2, "0") }}</p>
                 <div class="flex gap-1.5">
@@ -95,7 +95,7 @@ const projects: Project[] = [
             <div class="flex items-center gap-3">
               <span
                 v-if="project.featured"
-                class="inline-flex items-center gap-1.5 border border-[var(--color-accent)] bg-[rgba(245,255,0,0.08)] px-2 py-0.5 font-['JetBrains_Mono'] text-[0.66rem] font-semibold uppercase tracking-[0.14em] text-[var(--color-accent)]"
+                class="inline-flex items-center gap-1.5 border border-[var(--color-accent)] bg-[rgba(122,98,0,0.1)] px-2 py-0.5 font-['JetBrains_Mono'] text-[0.66rem] font-semibold uppercase tracking-[0.14em] text-[var(--color-accent)]"
               >
                 &#9733; Featured
               </span>

--- a/app/components/SkillsSection.vue
+++ b/app/components/SkillsSection.vue
@@ -55,7 +55,7 @@ const skillGroups: SkillGroup[] = [
         <li
           v-for="group in skillGroups"
           :key="group.category"
-          class="skills-animate grid gap-3 px-6 py-5 transition-colors duration-150 hover:bg-[rgba(245,255,0,0.02)] sm:grid-cols-[minmax(13rem,0.4fr)_1fr] sm:items-center sm:gap-8 sm:px-8 sm:py-6"
+          class="skills-animate grid gap-3 px-6 py-5 transition-colors duration-150 hover:bg-[rgba(122,98,0,0.04)] sm:grid-cols-[minmax(13rem,0.4fr)_1fr] sm:items-center sm:gap-8 sm:px-8 sm:py-6"
         >
           <div class="flex items-baseline gap-3">
             <span class="font-['JetBrains_Mono'] text-[0.72rem] font-semibold tracking-[0.16em] text-[var(--color-accent)]">{{ group.index }}</span>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,8 +9,8 @@ export default defineNuxtConfig({
     head: {
       link: [{ rel: "icon", type: "image/svg+xml", href: "/favicon.svg" }],
       meta: [
-        { name: "theme-color", content: "#050505" },
-        { name: "color-scheme", content: "dark" },
+        { name: "theme-color", content: "#f5f5f2" },
+        { name: "color-scheme", content: "light" },
       ],
     },
   },

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
-  <rect width="32" height="32" fill="#050505"/>
-  <rect x="0.5" y="0.5" width="31" height="31" fill="none" stroke="#2a2a2d" stroke-width="1"/>
-  <path d="M0 0 L8 0 L0 8 Z" fill="#f5ff00"/>
-  <path d="M32 32 L24 32 L32 24 Z" fill="#f5ff00"/>
-  <text x="16" y="22" font-family="'JetBrains Mono', monospace" font-size="15" font-weight="700" fill="#f5ff00" text-anchor="middle" letter-spacing="0.5">IA</text>
+  <rect width="32" height="32" fill="#f5f5f2"/>
+  <rect x="0.5" y="0.5" width="31" height="31" fill="none" stroke="#c4c4be" stroke-width="1"/>
+  <path d="M0 0 L8 0 L0 8 Z" fill="#7a6200"/>
+  <path d="M32 32 L24 32 L32 24 Z" fill="#7a6200"/>
+  <text x="16" y="22" font-family="'JetBrains Mono', monospace" font-size="15" font-weight="700" fill="#14141a" text-anchor="middle" letter-spacing="0.5">IA</text>
 </svg>


### PR DESCRIPTION
## Light mode conversion ☀️

Converted the site from the dark cyberpunk theme to a clean **light mode**, keeping the structural/typographic identity (monospace eyebrows, technical grid, corner ticks, clip-path buttons, hard shadows).

### Palette
- **Backgrounds:** warm off-white (`#f5f5f2`) page, white (`#fff`) cards/panels
- **Text:** near-black `#14141a` / muted `#56565f` / subtle `#86868e`
- **Accent:** dark gold `#7a6200` (neon yellow was invisible on white; darkened for legibility as both text and button color)
- **Borders:** light `#e1e1dc` / `#c4c4be`

### Changes
- Rewrote the `:root` CSS variable system (the core of the theme)
- Retuned for light: hard offset shadows, glow effects, body grid overlay, scanlines, media-frame gradient, hover tints, shimmer sweep
- Lightened hardcoded dark values in 6 components (header bar, mobile overlay, project mockups, skill rows, experience accent bar, contact grid)
- `theme-color` → `#f5f5f2`, `color-scheme` → `light`
- Favicon → light variant (dark "IA" on light bg)

### Notes
- Cyberpunk elements (grid, scanlines, glitch) are preserved but toned down for a light surface
- Verified live in a running dev preview; all contrast targets met for the accent as body/UI text
- ⚠️ The contact email / GitHub / LinkedIn links are still placeholders (`ivan@example.com`, generic URLs) — unchanged in this PR
